### PR TITLE
feat(scaffold): initialize project + schema v0 + data policy (GH #1/#2/#3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,8 @@ Thumbs.db
 
 # Beads (local working state if not using git-tracked db)
 .beads/
+
+# Beads local state (this project uses the GLOBAL personal DB at ~/.beads with raulmc- prefix)
+# Only the documentation README is tracked here.
+.beads/*
+!.beads/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,78 @@
+# Operation Prometheus - root gitignore
+# Per AGENTS.md: do not commit secrets, raw datasets, model weights, private files.
+
+# Secrets, credentials, tokens
+.env
+.env.*
+*.token
+secrets/
+credentials/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+.venv/
+venv/
+ENV/
+env/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.pytype/
+
+# Datasets (large/raw outputs per issue #1 and AGENTS.md)
+# Keep the .gitkeep files tracked, ignore actual data
+datasets/raw/*
+!datasets/raw/.gitkeep
+datasets/jsonl/*.jsonl
+!datasets/jsonl/.gitkeep
+
+# Model weights and large artifacts (never commit)
+models/
+*.pt
+*.pth
+*.bin
+*.safetensors
+*.onnx
+*.gguf
+*.h5
+*.ckpt
+
+# IDE / editor
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.project
+.pydevproject
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Beads (local working state if not using git-tracked db)
+.beads/

--- a/.gitignore
+++ b/.gitignore
@@ -43,9 +43,9 @@ env/
 datasets/raw/*
 !datasets/raw/.gitkeep
 
-# Note: datasets/jsonl/ is for cleaned small example JSONL and cards.
+# datasets/jsonl/ is for small cleaned example JSONL and cards.
 # Small curated JSONL files are allowed (see datasets/README.md).
-# We do not broadly ignore *.jsonl here so that valid small examples can be committed normally.
+# Do not ignore them broadly.
 
 # Model weights and large artifacts (never commit)
 models/

--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,10 @@ env/
 # Keep the .gitkeep files tracked, ignore actual data
 datasets/raw/*
 !datasets/raw/.gitkeep
-datasets/jsonl/*.jsonl
-!datasets/jsonl/.gitkeep
+
+# Note: datasets/jsonl/ is for cleaned small example JSONL and cards.
+# Small curated JSONL files are allowed (see datasets/README.md).
+# We do not broadly ignore *.jsonl here so that valid small examples can be committed normally.
 
 # Model weights and large artifacts (never commit)
 models/

--- a/.gitignore
+++ b/.gitignore
@@ -74,9 +74,6 @@ models/
 ehthumbs.db
 Thumbs.db
 
-# Beads (local working state if not using git-tracked db)
-.beads/
-
 # Beads local state (this project uses the GLOBAL personal DB at ~/.beads with raulmc- prefix)
 # Only the documentation README is tracked here.
 .beads/*

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Initial repositories include:
 
 - [docs/](docs/) — documentation and guides (including [data-policy.md](docs/data-policy.md))
 - [schemas/](schemas/) — data and trajectory schemas (JSON Schema v0 draft)
+- [providers/](providers/) — thin clients, adapters and config for external model / inference providers (no weights or large artifacts)
 - [scripts/](scripts/) — extraction, transformation, and validation scripts
 - [datasets/](datasets/) — local dataset outputs (raw data under `datasets/raw/` is gitignored; only small curated examples, cards, and manifests may be committed — see [datasets/README.md](datasets/README.md))
 - [evals/](evals/) — evaluation assets and prompts

--- a/README.md
+++ b/README.md
@@ -48,12 +48,19 @@ Initial repositories include:
 
 ## Repository Layout
 
-- [docs/](docs/) — documentation and guides
+- [docs/](docs/) — documentation and guides (including [data-policy.md](docs/data-policy.md))
 - [schemas/](schemas/) — data and trajectory schemas (Pydantic models + JSON Schema)
 - [scripts/](scripts/) — extraction, transformation, and validation scripts
 - [datasets/](datasets/) — local dataset outputs (raw data and large JSONL files are gitignored; commit only small examples and cards)
 - [evals/](evals/) — evaluation assets and prompts
 
 See [datasets/README.md](datasets/README.md) for rules on what may be committed.
+
+## Schemas and Data Policy
+
+- **Schema v0** (initial draft, not final): [schemas/pr_trajectory.schema.json](schemas/pr_trajectory.schema.json). Implements GitHub [#2](https://github.com/rmems/operation-prometheus/issues/2). See the tiny example in `datasets/examples/`.
+- **Data policy & hygiene**: [docs/data-policy.md](docs/data-policy.md). Implements GitHub [#3](https://github.com/rmems/operation-prometheus/issues/3). Covers allowed public sources, excluded material, manual inspection requirement, and the distinction between public engineering history vs. raw chat log scraping.
+
+These are tracked in the global beads DB (prefix `raulmc-`): `raulmc-vge` and `raulmc-9cq`.
 
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,14 @@ Initial repositories include:
 * magere-brug
 * Future Limen-Neural projects
 
-## Long-Term Vision
+## Repository Layout
 
-Operation Prometheus aims to become a personal engineering memory system capable of teaching future local models how software evolves through review, experimentation, validation, and iteration.
+- [docs/](docs/) — documentation and guides
+- [schemas/](schemas/) — data and trajectory schemas (Pydantic models + JSON Schema)
+- [scripts/](scripts/) — extraction, transformation, and validation scripts
+- [datasets/](datasets/) — local dataset outputs (raw data and large JSONL files are gitignored; commit only small examples and cards)
+- [evals/](evals/) — evaluation assets and prompts
 
-The goal is not merely code generation.
+See [datasets/README.md](datasets/README.md) for rules on what may be committed.
 
-The goal is engineering understanding.
+

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Initial repositories include:
 - [docs/](docs/) — documentation and guides (including [data-policy.md](docs/data-policy.md))
 - [schemas/](schemas/) — data and trajectory schemas (JSON Schema v0 draft)
 - [scripts/](scripts/) — extraction, transformation, and validation scripts
-- [datasets/](datasets/) — local dataset outputs (raw data and large JSONL files are gitignored; commit only small examples and cards)
+- [datasets/](datasets/) — local dataset outputs (raw data under `datasets/raw/` is gitignored; only small curated examples, cards, and manifests may be committed — see [datasets/README.md](datasets/README.md))
 - [evals/](evals/) — evaluation assets and prompts
 
 See [datasets/README.md](datasets/README.md) for rules on what may be committed.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Initial repositories include:
 ## Repository Layout
 
 - [docs/](docs/) — documentation and guides (including [data-policy.md](docs/data-policy.md))
-- [schemas/](schemas/) — data and trajectory schemas (Pydantic models + JSON Schema)
+- [schemas/](schemas/) — data and trajectory schemas (JSON Schema v0 draft)
 - [scripts/](scripts/) — extraction, transformation, and validation scripts
 - [datasets/](datasets/) — local dataset outputs (raw data and large JSONL files are gitignored; commit only small examples and cards)
 - [evals/](evals/) — evaluation assets and prompts

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,0 +1,19 @@
+# Datasets
+
+This directory contains generated artifacts for Operation Prometheus trajectory datasets.
+
+**Critical rules (see also root `.gitignore` and [AGENTS.md](../AGENTS.md)):**
+
+- **Do not commit large raw datasets** or full GitHub issue/PR exports here.
+- **Do not commit model weights** or other large binary artifacts.
+- `datasets/raw/` is intended for local, temporary raw collection output from GitHub (gitignored).
+- `datasets/jsonl/` is for cleaned, linked JSONL trajectory records — only commit small example files, schema samples, or cards.
+- `datasets/cards/` holds lightweight metadata cards describing datasets (these are safe to commit).
+
+Large data should live outside the repo (e.g. on object storage, Dolt, or a separate private datasets repo) and be referenced via manifests or cards.
+
+This keeps the repository small, inspectable, and compliant with the project's prime directive and "Do Not" guidelines.
+
+See:
+- [AGENTS.md](../AGENTS.md) for overall rules
+- `schemas/` (when populated) for the canonical data shapes

--- a/datasets/cards/.gitkeep
+++ b/datasets/cards/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep datasets/cards/ directory tracked in git

--- a/datasets/examples/.gitkeep
+++ b/datasets/examples/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder for small committed example trajectory records (see issue #2)

--- a/datasets/examples/trajectory-v0-example.json
+++ b/datasets/examples/trajectory-v0-example.json
@@ -1,0 +1,29 @@
+{
+  "id": "corinth-canal-42",
+  "repo": "rmems/corinth-canal",
+  "pr_number": 42,
+  "source_urls": [
+    "https://github.com/rmems/corinth-canal/pull/42",
+    "https://github.com/rmems/corinth-canal/issues/41"
+  ],
+  "language": "Rust",
+  "domain": "infra",
+  "task_type": "bugfix",
+  "issue_context": "CI was flaky on macOS due to missing env var for a native lib.",
+  "review_signals": [
+    {
+      "author": "reviewer-x",
+      "comment": "We should set the var explicitly in the workflow instead of relying on the runner image.",
+      "suggestion": "add `FOO_NATIVE=1` to the macos job env"
+    }
+  ],
+  "before_context": "The workflow file had no explicit FOO_NATIVE for macos runner.",
+  "patch": "--- a/.github/workflows/ci.yml\n+++ b/.github/workflows/ci.yml\n@@\n-      - run: cargo test\n+      - env:\n+          FOO_NATIVE: \"1\"\n+        run: cargo test",
+  "validation": [
+    { "type": "ci", "result": "pass", "detail": "macos job green after 3 runs" },
+    { "type": "test", "result": "pass", "detail": "all tests passing locally" }
+  ],
+  "outcome": "merged",
+  "training_use": "validation",
+  "quality_score": 0.85
+}

--- a/datasets/examples/trajectory-v0-example.json
+++ b/datasets/examples/trajectory-v0-example.json
@@ -18,7 +18,7 @@
     }
   ],
   "before_context": "The workflow file had no explicit FOO_NATIVE for macos runner.",
-  "patch": "--- a/.github/workflows/ci.yml\n+++ b/.github/workflows/ci.yml\n@@\n-      - run: cargo test\n+      - env:\n+          FOO_NATIVE: \"1\"\n+        run: cargo test",
+  "patch": "--- a/.github/workflows/ci.yml\n+++ b/.github/workflows/ci.yml\n@@ -10,7 +10,9 @@ jobs:\n   test:\n     runs-on: macos-latest\n     steps:\n-      - run: cargo test\n+      - env:\n+          FOO_NATIVE: \"1\"\n+        run: cargo test",
   "validation": [
     { "type": "ci", "result": "pass", "detail": "macos job green after 3 runs" },
     { "type": "test", "result": "pass", "detail": "all tests passing locally" }

--- a/datasets/examples/trajectory-v0-example.json
+++ b/datasets/examples/trajectory-v0-example.json
@@ -1,10 +1,9 @@
 {
-  "id": "corinth-canal-42",
-  "repo": "rmems/corinth-canal",
-  "pr_number": 42,
+  "id": "ci-demo-17",
+  "repo": "rmems/ci-demo",
+  "pr_number": 17,
   "source_urls": [
-    "https://github.com/rmems/corinth-canal/pull/42",
-    "https://github.com/rmems/corinth-canal/issues/41"
+    "https://github.com/rmems/ci-demo/pull/17"
   ],
   "language": "Rust",
   "domain": "infra",
@@ -18,7 +17,7 @@
     }
   ],
   "before_context": "The workflow file had no explicit FOO_NATIVE for macos runner.",
-  "patch": "--- a/.github/workflows/ci.yml\n+++ b/.github/workflows/ci.yml\n@@ -10,7 +10,9 @@ jobs:\n   test:\n     runs-on: macos-latest\n     steps:\n-      - run: cargo test\n+      - env:\n+          FOO_NATIVE: \"1\"\n+        run: cargo test",
+  "patch": "--- a/.github/workflows/ci.yml\n+++ b/.github/workflows/ci.yml\n@@ -5,4 +5,6 @@ jobs:\n     runs-on: macos-latest\n     steps:\n       - uses: actions/checkout@v4\n-      - run: cargo test\n+      - env:\n+          FOO_NATIVE: \"1\"\n+        run: cargo test",
   "validation": [
     { "type": "ci", "result": "pass", "detail": "macos job green after 3 runs" },
     { "type": "test", "result": "pass", "detail": "all tests passing locally" }

--- a/datasets/jsonl/.gitkeep
+++ b/datasets/jsonl/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep datasets/jsonl/ directory tracked in git (commit only small examples)

--- a/datasets/raw/.gitkeep
+++ b/datasets/raw/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep datasets/raw/ directory tracked in git (raw data should not be committed)

--- a/docs/.gitkeep
+++ b/docs/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep docs/ directory tracked in git

--- a/docs/data-policy.md
+++ b/docs/data-policy.md
@@ -1,0 +1,64 @@
+# Data Policy and Dataset Hygiene
+
+**Status**: Draft (implements GitHub issue #3)
+
+Operation Prometheus converts **public** GitHub engineering history into structured training datasets.
+
+We are committed to responsible use of public artifacts and keeping the repository small, inspectable, and free of sensitive material.
+
+## Allowed Public Sources
+
+We may extract and normalize from public repositories:
+
+- PR metadata (titles, bodies, labels, milestones, state transitions)
+- Issue and PR comments (public discussion)
+- Review comments and suggestions
+- Diffs and commits (code changes)
+- CI / check run summaries (public workflow results)
+- Safe experiment artifacts that were intentionally made public (e.g. benchmark outputs, public logs)
+
+All of the above must come from repositories that are publicly accessible without authentication.
+
+## Excluded Sources
+
+We **must not** commit or use as primary training data:
+
+- Private credentials, tokens, API keys, or secrets of any kind
+- Private local configuration files (e.g. `.env`, personal machine settings)
+- Raw closed-model chat logs as the primary training corpus (per AGENTS.md "Do Not")
+- Large model weights or artifacts committed directly to this Git repository (see AGENTS.md and `.gitignore`)
+- Private or internal-only discussions, even if accidentally exposed
+
+Raw GitHub API exports (issues.jsonl, prs.jsonl, etc.) are treated as **temporary working artifacts** until they have been:
+1. Normalized into trajectory records
+2. Manually inspected for policy compliance
+3. Reduced to the minimal public signal needed
+
+Large raw exports should live outside the repo (local disk, object storage, or a private datasets mirror) and are gitignored by default.
+
+## Manual Inspection Requirement
+
+Before any generated dataset is published or used for training:
+
+- A human (or explicit recorded review step) must inspect a sample of the records.
+- Confirm that no excluded material is present.
+- Confirm that the trajectory still carries useful engineering signal (issue → review → patch → validation → outcome).
+
+## Public Engineering History vs. Chat Log Scraping
+
+This project focuses on the **engineering trajectory** visible in public code review and version control:
+
+```
+issue/review signal → before state → patch/fix → validation → outcome
+```
+
+It is **not** a general web scrape of LLM chat logs. Public PR discussion, code review, and commit history are distinct from proprietary model outputs or private conversation transcripts.
+
+See also:
+- [AGENTS.md](../AGENTS.md) — "Do Not" section and prime directive
+- Root `.gitignore` — rules for raw data and model weights
+- [datasets/README.md](../datasets/README.md) — guidance on what may be committed
+
+## Questions or Concerns
+
+Open an issue or discussion in this repository. All policy updates should be tracked as changes to this document and referenced from the root README.

--- a/docs/data-policy.md
+++ b/docs/data-policy.md
@@ -48,7 +48,7 @@ Before any generated dataset is published or used for training:
 
 This project focuses on the **engineering trajectory** visible in public code review and version control:
 
-```
+```text
 issue/review signal → before state → patch/fix → validation → outcome
 ```
 

--- a/evals/.gitkeep
+++ b/evals/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep evals/ directory tracked in git

--- a/providers/README.md
+++ b/providers/README.md
@@ -1,0 +1,31 @@
+# Providers
+
+Configuration, thin clients, and adapters for **external model / inference providers**.
+
+This project uses external providers (e.g. xAI, OpenAI-compatible, Anthropic, local Ollama/vLLM) instead of checking model weights into the repository.
+
+## What belongs here
+- Provider client wrappers or config schemas (for evals, future extraction agents, etc.)
+- Example environment variable names and endpoint configuration
+- Thin adapter code (no weights, no large artifacts)
+
+## What does NOT belong here
+- API keys, tokens, or credentials (use environment variables or secret stores)
+- Model weights, checkpoints, GGUF files, safetensors, etc.
+- Large downloaded model artifacts
+
+See:
+- [AGENTS.md](../AGENTS.md) (Do Not section)
+- [docs/data-policy.md](../docs/data-policy.md)
+- Root [.gitignore](../.gitignore)
+
+## Example layout (future)
+```
+providers/
+  xai/
+  openai/
+  anthropic/
+  local/
+```
+
+Keep this directory small and focused on integration, not assets.

--- a/schemas/.gitkeep
+++ b/schemas/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep schemas/ directory tracked in git

--- a/schemas/pr_trajectory.schema.json
+++ b/schemas/pr_trajectory.schema.json
@@ -48,13 +48,11 @@
       "items": {
         "type": "object",
         "properties": {
-          "author": { "type": "string" },
-          "comment": { "type": "string" },
-          "suggestion": { "type": "string" }
-        },
           "author": { "type": "string", "minLength": 1 },
           "comment": { "type": "string", "minLength": 1 },
           "suggestion": { "type": "string", "minLength": 1 }
+        },
+        "required": ["author", "comment", "suggestion"],
         "additionalProperties": false
       },
       "description": "Key review comments or suggestions that drove changes."
@@ -75,9 +73,9 @@
         "properties": {
           "type": { "type": "string", "enum": ["ci", "test", "manual", "review", "other"] },
           "result": { "type": "string", "enum": ["pass", "fail", "flaky"] },
-          "detail": { "type": "string" }
-        },
           "detail": { "type": "string", "minLength": 1 }
+        },
+        "required": ["type", "result", "detail"],
         "additionalProperties": false
       },
       "description": "Validation events (CI runs, test results, manual verification) after the change."

--- a/schemas/pr_trajectory.schema.json
+++ b/schemas/pr_trajectory.schema.json
@@ -18,6 +18,7 @@
     },
     "pr_number": {
       "type": "integer",
+      "minimum": 1,
       "description": "Pull request number within the repo."
     },
     "source_urls": {
@@ -52,13 +53,34 @@
           "comment": { "type": "string", "minLength": 1 },
           "suggestion": { "type": "string", "minLength": 1 }
         },
-        "required": ["author", "comment", "suggestion"],
+        "required": ["comment"],
+        "additionalProperties": false
+      },
+      "description": "Key review comments or suggestions that drove changes."
+    },
+        "required": ["comment"],
+        "additionalProperties": false
+      },
+      "description": "Key review comments or suggestions that drove changes."
+    },
+        "required": ["comment"],
+        "additionalProperties": false
+      },
+      "description": "Key review comments or suggestions that drove changes."
+    },
+        "required": ["comment"],
+        "additionalProperties": false
+      },
+      "description": "Key review comments or suggestions that drove changes."
+    },
+        "required": ["comment"],
         "additionalProperties": false
       },
       "description": "Key review comments or suggestions that drove changes."
     },
     "before_context": {
       "type": "string",
+      "minLength": 1,
       "description": "Relevant code/state before the patch (snippets or file references)."
     },
     "patch": {
@@ -68,6 +90,7 @@
     },
     "validation": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "type": "object",
         "properties": {
@@ -75,6 +98,26 @@
           "result": { "type": "string", "enum": ["pass", "fail", "flaky"] },
           "detail": { "type": "string", "minLength": 1 }
         },
+        "required": ["type", "result", "detail"],
+        "additionalProperties": false
+      },
+      "description": "Validation events (CI runs, test results, manual verification) after the change."
+    },
+        "required": ["type", "result", "detail"],
+        "additionalProperties": false
+      },
+      "description": "Validation events (CI runs, test results, manual verification) after the change."
+    },
+        "required": ["type", "result", "detail"],
+        "additionalProperties": false
+      },
+      "description": "Validation events (CI runs, test results, manual verification) after the change."
+    },
+        "required": ["type", "result", "detail"],
+        "additionalProperties": false
+      },
+      "description": "Validation events (CI runs, test results, manual verification) after the change."
+    },
         "required": ["type", "result", "detail"],
         "additionalProperties": false
       },

--- a/schemas/pr_trajectory.schema.json
+++ b/schemas/pr_trajectory.schema.json
@@ -4,7 +4,20 @@
   "title": "PR Trajectory v0",
   "description": "Initial JSON schema for a software-engineering trajectory extracted from a public GitHub PR. This is schema v0 (not final). See GitHub issue #2.",
   "type": "object",
-  "required": ["id", "repo", "pr_number", "source_urls", "language", "domain", "task_type", "before_context", "patch", "validation", "outcome", "training_use"],
+  "required": [
+    "id",
+    "repo",
+    "pr_number",
+    "source_urls",
+    "language",
+    "domain",
+    "task_type",
+    "before_context",
+    "patch",
+    "validation",
+    "outcome",
+    "training_use"
+  ],
   "properties": {
     "id": {
       "type": "string",
@@ -24,39 +37,78 @@
     "source_urls": {
       "type": "array",
       "minItems": 1,
-      "items": { "type": "string", "format": "uri" },
-      "description": "Links to the PR, issue, and/or specific review threads that contributed signal."
+      "items": {
+        "type": "string",
+        "format": "uri",
+        "pattern": "^https://github\\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/(pull|issues)/[0-9]+(?:#.*)?$"
+      },
+      "description": "Public GitHub PR/issue URLs that contributed provenance or review signal."
     },
     "language": {
       "type": "string",
-      "description": "Primary programming language of the change (e.g. Rust, Python, Julia)."
+      "description": "Primary programming language of the change (e.g. Rust, Python, Julia).",
+      "minLength": 1
     },
     "domain": {
       "type": "string",
-      "description": "Application domain (e.g. ML-infra, systems, data-pipeline, web)."
+      "description": "Application domain (e.g. ML-infra, systems, data-pipeline, web).",
+      "minLength": 1
     },
     "task_type": {
       "type": "string",
-      "enum": ["bugfix", "feature", "refactor", "docs", "test", "perf", "security", "chore", "other"],
+      "enum": [
+        "bugfix",
+        "feature",
+        "refactor",
+        "docs",
+        "test",
+        "perf",
+        "security",
+        "chore",
+        "other"
+      ],
       "description": "High-level classification of the engineering task."
     },
     "issue_context": {
       "type": "string",
-      "description": "Summary of the originating issue or motivation (public text only)."
+      "description": "Summary of the originating issue or motivation (public text only).",
+      "minLength": 1
     },
     "review_signals": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "author": { "type": "string", "minLength": 1 },
-          "comment": { "type": "string", "minLength": 1 },
-          "suggestion": { "type": "string", "minLength": 1 }
+          "author": {
+            "type": "string",
+            "minLength": 1
+          },
+          "comment": {
+            "type": "string",
+            "minLength": 1
+          },
+          "suggestion": {
+            "type": "string",
+            "minLength": 1
+          }
         },
-        "required": ["comment"],
-        "additionalProperties": false
+        "required": [],
+        "additionalProperties": false,
+        "anyOf": [
+          {
+            "required": [
+              "comment"
+            ]
+          },
+          {
+            "required": [
+              "suggestion"
+            ]
+          }
+        ]
       },
-      "description": "Key review comments or suggestions that drove changes."
+      "description": "Key review comments or suggestions that drove changes. Each item must include a non-empty comment or suggestion.",
+      "minItems": 1
     },
     "before_context": {
       "type": "string",
@@ -74,23 +126,57 @@
       "items": {
         "type": "object",
         "properties": {
-          "type": { "type": "string", "enum": ["ci", "test", "manual", "review", "other"] },
-          "result": { "type": "string", "enum": ["pass", "fail", "flaky"] },
-          "detail": { "type": "string", "minLength": 1 }
+          "type": {
+            "type": "string",
+            "enum": [
+              "ci",
+              "test",
+              "manual",
+              "review",
+              "other"
+            ]
+          },
+          "result": {
+            "type": "string",
+            "enum": [
+              "pass",
+              "fail",
+              "flaky"
+            ]
+          },
+          "detail": {
+            "type": "string",
+            "minLength": 1
+          }
         },
-        "required": ["type", "result"],
+        "required": [
+          "type",
+          "result"
+        ],
         "additionalProperties": false
       },
       "description": "Validation events (CI runs, test results, manual verification) after the change."
     },
     "outcome": {
       "type": "string",
-      "enum": ["merged", "closed", "superseded", "abandoned"],
+      "enum": [
+        "merged",
+        "closed",
+        "superseded",
+        "abandoned"
+      ],
       "description": "Final state of the PR."
     },
     "training_use": {
       "type": "string",
-      "enum": ["repair", "autocomplete", "review-to-patch", "bug-prediction", "validation", "other"],
+      "enum": [
+        "repair",
+        "autocomplete",
+        "review-to-patch",
+        "bug-prediction",
+        "validation",
+        "other"
+      ],
       "description": "Intended primary training signal this trajectory provides."
     },
     "quality_score": {
@@ -100,5 +186,17 @@
       "description": "Optional human or heuristic quality score for filtering (0-1)."
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "anyOf": [
+    {
+      "required": [
+        "issue_context"
+      ]
+    },
+    {
+      "required": [
+        "review_signals"
+      ]
+    }
+  ]
 }

--- a/schemas/pr_trajectory.schema.json
+++ b/schemas/pr_trajectory.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/rmems/operation-prometheus/schemas/pr_trajectory.schema.json",
+  "title": "PR Trajectory v0",
+  "description": "Initial JSON schema for a software-engineering trajectory extracted from a public GitHub PR. This is schema v0 (not final). See GitHub issue #2.",
+  "type": "object",
+  "required": ["id", "repo", "pr_number", "source_urls", "language", "domain", "task_type", "before_context", "patch", "validation", "outcome", "training_use"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Stable identifier for this trajectory record (e.g. repo-pr-123 or hash)."
+    },
+    "repo": {
+      "type": "string",
+      "description": "GitHub repository in owner/repo form."
+    },
+    "pr_number": {
+      "type": "integer",
+      "description": "Pull request number within the repo."
+    },
+    "source_urls": {
+      "type": "array",
+      "items": { "type": "string", "format": "uri" },
+      "description": "Links to the PR, issue, and/or specific review threads that contributed signal."
+    },
+    "language": {
+      "type": "string",
+      "description": "Primary programming language of the change (e.g. Rust, Python, Julia)."
+    },
+    "domain": {
+      "type": "string",
+      "description": "Application domain (e.g. ML-infra, systems, data-pipeline, web)."
+    },
+    "task_type": {
+      "type": "string",
+      "enum": ["bugfix", "feature", "refactor", "docs", "test", "perf", "security", "chore", "other"],
+      "description": "High-level classification of the engineering task."
+    },
+    "issue_context": {
+      "type": "string",
+      "description": "Summary of the originating issue or motivation (public text only)."
+    },
+    "review_signals": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "author": { "type": "string" },
+          "comment": { "type": "string" },
+          "suggestion": { "type": "string" }
+        }
+      },
+      "description": "Key review comments or suggestions that drove changes."
+    },
+    "before_context": {
+      "type": "string",
+      "description": "Relevant code/state before the patch (snippets or file references)."
+    },
+    "patch": {
+      "type": "string",
+      "description": "Unified diff or structured patch representing the fix/implementation."
+    },
+    "validation": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string", "enum": ["ci", "test", "manual", "review", "other"] },
+          "result": { "type": "string", "enum": ["pass", "fail", "flaky"] },
+          "detail": { "type": "string" }
+        }
+      },
+      "description": "Validation events (CI runs, test results, manual verification) after the change."
+    },
+    "outcome": {
+      "type": "string",
+      "enum": ["merged", "closed", "superseded", "abandoned"],
+      "description": "Final state of the PR."
+    },
+    "training_use": {
+      "type": "string",
+      "enum": ["repair", "autocomplete", "review-to-patch", "bug-prediction", "validation", "other"],
+      "description": "Intended primary training signal this trajectory provides."
+    },
+    "quality_score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Optional human or heuristic quality score for filtering (0-1)."
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/pr_trajectory.schema.json
+++ b/schemas/pr_trajectory.schema.json
@@ -42,7 +42,7 @@
         "format": "uri",
         "pattern": "^https://github\\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/(pull|issues)/[0-9]+(?:#.*)?$"
       },
-      "description": "Public GitHub PR/issue URLs that contributed provenance or review signal."
+      "description": "Public GitHub PR/issue URLs that contributed provenance or review signal. MUST include the canonical PR URL for the declared repo and pr_number (https://github.com/{repo}/pull/{pr_number}). Cross-repo supplemental links are allowed but the primary trajectory's own PR must be present for auditability."
     },
     "language": {
       "type": "string",
@@ -198,5 +198,16 @@
         "review_signals"
       ]
     }
-  ]
+  ],
+  "if": {
+    "properties": {
+      "training_use": { "const": "review-to-patch" }
+    }
+  },
+  "then": {
+    "required": ["review_signals"],
+    "properties": {
+      "review_signals": { "minItems": 1 }
+    }
+  }
 }

--- a/schemas/pr_trajectory.schema.json
+++ b/schemas/pr_trajectory.schema.json
@@ -8,10 +8,12 @@
   "properties": {
     "id": {
       "type": "string",
+      "minLength": 1,
       "description": "Stable identifier for this trajectory record (e.g. repo-pr-123 or hash)."
     },
     "repo": {
       "type": "string",
+      "pattern": "^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$",
       "description": "GitHub repository in owner/repo form."
     },
     "pr_number": {
@@ -20,6 +22,7 @@
     },
     "source_urls": {
       "type": "array",
+      "minItems": 1,
       "items": { "type": "string", "format": "uri" },
       "description": "Links to the PR, issue, and/or specific review threads that contributed signal."
     },
@@ -48,7 +51,9 @@
           "author": { "type": "string" },
           "comment": { "type": "string" },
           "suggestion": { "type": "string" }
-        }
+        },
+        "required": ["comment"],
+        "additionalProperties": false
       },
       "description": "Key review comments or suggestions that drove changes."
     },
@@ -58,6 +63,7 @@
     },
     "patch": {
       "type": "string",
+      "minLength": 1,
       "description": "Unified diff or structured patch representing the fix/implementation."
     },
     "validation": {
@@ -68,7 +74,9 @@
           "type": { "type": "string", "enum": ["ci", "test", "manual", "review", "other"] },
           "result": { "type": "string", "enum": ["pass", "fail", "flaky"] },
           "detail": { "type": "string" }
-        }
+        },
+        "required": ["type", "result"],
+        "additionalProperties": false
       },
       "description": "Validation events (CI runs, test results, manual verification) after the change."
     },

--- a/schemas/pr_trajectory.schema.json
+++ b/schemas/pr_trajectory.schema.json
@@ -78,6 +78,11 @@
       },
       "description": "Key review comments or suggestions that drove changes."
     },
+        "required": ["comment"],
+        "additionalProperties": false
+      },
+      "description": "Key review comments or suggestions that drove changes."
+    },
     "before_context": {
       "type": "string",
       "minLength": 1,
@@ -98,6 +103,11 @@
           "result": { "type": "string", "enum": ["pass", "fail", "flaky"] },
           "detail": { "type": "string", "minLength": 1 }
         },
+        "required": ["type", "result"],
+        "additionalProperties": false
+      },
+      "description": "Validation events (CI runs, test results, manual verification) after the change."
+    },
         "required": ["type", "result", "detail"],
         "additionalProperties": false
       },

--- a/schemas/pr_trajectory.schema.json
+++ b/schemas/pr_trajectory.schema.json
@@ -52,7 +52,9 @@
           "comment": { "type": "string" },
           "suggestion": { "type": "string" }
         },
-        "required": ["author", "comment", "suggestion"],
+          "author": { "type": "string", "minLength": 1 },
+          "comment": { "type": "string", "minLength": 1 },
+          "suggestion": { "type": "string", "minLength": 1 }
         "additionalProperties": false
       },
       "description": "Key review comments or suggestions that drove changes."

--- a/schemas/pr_trajectory.schema.json
+++ b/schemas/pr_trajectory.schema.json
@@ -58,6 +58,11 @@
       },
       "description": "Key review comments or suggestions that drove changes."
     },
+        "required": ["comment"],
+        "additionalProperties": false
+      },
+      "description": "Key review comments or suggestions that drove changes."
+    },
     "before_context": {
       "type": "string",
       "minLength": 1,
@@ -78,6 +83,11 @@
           "result": { "type": "string", "enum": ["pass", "fail", "flaky"] },
           "detail": { "type": "string", "minLength": 1 }
         },
+        "required": ["type", "result"],
+        "additionalProperties": false
+      },
+      "description": "Validation events (CI runs, test results, manual verification) after the change."
+    },
         "required": ["type", "result"],
         "additionalProperties": false
       },

--- a/schemas/pr_trajectory.schema.json
+++ b/schemas/pr_trajectory.schema.json
@@ -77,7 +77,7 @@
           "result": { "type": "string", "enum": ["pass", "fail", "flaky"] },
           "detail": { "type": "string" }
         },
-        "required": ["type", "result", "detail"],
+          "detail": { "type": "string", "minLength": 1 }
         "additionalProperties": false
       },
       "description": "Validation events (CI runs, test results, manual verification) after the change."

--- a/schemas/pr_trajectory.schema.json
+++ b/schemas/pr_trajectory.schema.json
@@ -58,11 +58,6 @@
       },
       "description": "Key review comments or suggestions that drove changes."
     },
-        "required": ["comment"],
-        "additionalProperties": false
-      },
-      "description": "Key review comments or suggestions that drove changes."
-    },
     "before_context": {
       "type": "string",
       "minLength": 1,
@@ -83,11 +78,6 @@
           "result": { "type": "string", "enum": ["pass", "fail", "flaky"] },
           "detail": { "type": "string", "minLength": 1 }
         },
-        "required": ["type", "result"],
-        "additionalProperties": false
-      },
-      "description": "Validation events (CI runs, test results, manual verification) after the change."
-    },
         "required": ["type", "result"],
         "additionalProperties": false
       },

--- a/schemas/pr_trajectory.schema.json
+++ b/schemas/pr_trajectory.schema.json
@@ -52,7 +52,7 @@
           "comment": { "type": "string" },
           "suggestion": { "type": "string" }
         },
-        "required": ["comment"],
+        "required": ["author", "comment", "suggestion"],
         "additionalProperties": false
       },
       "description": "Key review comments or suggestions that drove changes."
@@ -75,7 +75,7 @@
           "result": { "type": "string", "enum": ["pass", "fail", "flaky"] },
           "detail": { "type": "string" }
         },
-        "required": ["type", "result"],
+        "required": ["type", "result", "detail"],
         "additionalProperties": false
       },
       "description": "Validation events (CI runs, test results, manual verification) after the change."

--- a/schemas/pr_trajectory.schema.json
+++ b/schemas/pr_trajectory.schema.json
@@ -58,31 +58,6 @@
       },
       "description": "Key review comments or suggestions that drove changes."
     },
-        "required": ["comment"],
-        "additionalProperties": false
-      },
-      "description": "Key review comments or suggestions that drove changes."
-    },
-        "required": ["comment"],
-        "additionalProperties": false
-      },
-      "description": "Key review comments or suggestions that drove changes."
-    },
-        "required": ["comment"],
-        "additionalProperties": false
-      },
-      "description": "Key review comments or suggestions that drove changes."
-    },
-        "required": ["comment"],
-        "additionalProperties": false
-      },
-      "description": "Key review comments or suggestions that drove changes."
-    },
-        "required": ["comment"],
-        "additionalProperties": false
-      },
-      "description": "Key review comments or suggestions that drove changes."
-    },
     "before_context": {
       "type": "string",
       "minLength": 1,
@@ -104,31 +79,6 @@
           "detail": { "type": "string", "minLength": 1 }
         },
         "required": ["type", "result"],
-        "additionalProperties": false
-      },
-      "description": "Validation events (CI runs, test results, manual verification) after the change."
-    },
-        "required": ["type", "result", "detail"],
-        "additionalProperties": false
-      },
-      "description": "Validation events (CI runs, test results, manual verification) after the change."
-    },
-        "required": ["type", "result", "detail"],
-        "additionalProperties": false
-      },
-      "description": "Validation events (CI runs, test results, manual verification) after the change."
-    },
-        "required": ["type", "result", "detail"],
-        "additionalProperties": false
-      },
-      "description": "Validation events (CI runs, test results, manual verification) after the change."
-    },
-        "required": ["type", "result", "detail"],
-        "additionalProperties": false
-      },
-      "description": "Validation events (CI runs, test results, manual verification) after the change."
-    },
-        "required": ["type", "result", "detail"],
         "additionalProperties": false
       },
       "description": "Validation events (CI runs, test results, manual verification) after the change."

--- a/schemas/pr_trajectory.schema.json
+++ b/schemas/pr_trajectory.schema.json
@@ -26,8 +26,8 @@
     },
     "repo": {
       "type": "string",
-      "pattern": "^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$",
-      "description": "GitHub repository in owner/repo form."
+      "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?/[a-zA-Z0-9][a-zA-Z0-9_.-]{0,99}$",
+      "description": "GitHub repository in owner/repo form. Owner must be a valid GitHub user or organization login (alphanumeric or hyphen, 1-39 chars, cannot start or end with hyphen). Repo name follows GitHub rules."
     },
     "pr_number": {
       "type": "integer",
@@ -200,6 +200,7 @@
     }
   ],
   "if": {
+    "required": ["training_use"],
     "properties": {
       "training_use": { "const": "review-to-patch" }
     }

--- a/scripts/.gitkeep
+++ b/scripts/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep scripts/ directory tracked in git


### PR DESCRIPTION
## **User description**
# feat(scaffold): initialize project + schema v0 + data policy (GH #1/#2/#3)

## Summary

Initial project scaffolding and foundational artifacts for Operation Prometheus.

- Completes GitHub [#1](https://github.com/rmems/operation-prometheus/issues/1): Project scaffold (directories + .gitkeep, root .gitignore, datasets/README.md, README layout links). **No `models/` directory created per instruction.**
- Implements GitHub [#2](https://github.com/rmems/operation-prometheus/issues/2): Define trajectory JSON schema v0
  - `schemas/pr_trajectory.schema.json` (draft v0, not final)
  - Required fields + enums for `task_type`, `outcome`, `training_use`
  - Tiny committed example: `datasets/examples/trajectory-v0-example.json`
  - Basic validation passes
- Implements GitHub [#3](https://github.com/rmems/operation-prometheus/issues/3): Data policy and dataset hygiene rules
  - `docs/data-policy.md`
  - Allowed public sources, excluded sources, manual inspection requirement
  - Distinguishes public engineering history vs. raw chat log scraping
  - Aligns with AGENTS.md "Do Not" section

Also adds support for using the **global personal Beads DB** (`raulmc-` prefix) from this repo:
- `.beads/README.md` documents `BEADS_DIR=/home/raulmc/.beads` usage
- `.gitignore` updated to ignore `.beads/*` except the README (no local DB fragmentation)
- Tracked beads issues: `raulmc-vge` and `raulmc-9cq` (created, claimed, implemented, closed)

## Changes

```
.gitignore
README.md
.beads/README.md
docs/data-policy.md
schemas/pr_trajectory.schema.json
datasets/examples/.gitkeep
datasets/examples/trajectory-v0-example.json
+ .gitkeep files in docs/, schemas/, scripts/, evals/, datasets/{cards,jsonl,raw}/
```

## Type of Change

- [x] Documentation / scaffold / initial setup
- [x] New schema (v0 draft)
- [x] Policy / hygiene rules

## Pre-flight Checklist

- [x] `git status` clean before commit
- [x] AGENTS.md validation run (`ruff check`, `pytest -q`, validate script placeholders)
- [x] Beads used for tracking (`bd create`, `--claim`, `close`)
- [x] No secrets / raw data / model weights committed
- [x] Pushed to both `github` and `gitlab` remotes for testing

## Testing

- Schema example validates against the v0 JSON schema (lightweight Python check)
- All files staged/committed cleanly on `feat/initialize-scaffold`
- Branch pushed to both remotes

## Related

- GitHub issues: #1, #2, #3
- Beads (global DB): raulmc-vge, raulmc-9cq
- Branch: `feat/initialize-scaffold`

This is the foundation before any GitHub extraction scripts or larger datasets.


___

## **CodeAnt-AI Description**
**Set up the project structure and document the first trajectory data rules**

### What Changed
- Added the main repo folders for docs, schemas, scripts, evals, and dataset outputs so the project has a clear layout from the start
- Documented what can and cannot be committed in datasets, including small examples, cards, and local-only raw data
- Added the first trajectory schema and a sample record to show the expected data shape
- Published the data policy covering allowed public sources, excluded material, and the manual review step before training use
- Updated the README with the new layout and links to the schema and policy

### Impact
`✅ Clearer dataset submission rules`
`✅ Easier navigation of the repository`
`✅ Safer public-data collection`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
