### PR TITLE
feat: PROMETHEUS_DATA_ROOT sibling layout + scale collect helpers (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,17 @@ pip install -r requirements.txt
 
 export GITHUB_TOKEN=...   # optional; higher rate limits
 
-# Optional: large raw dumps outside the git tree (issue #14)
+# Optional: large raw dumps outside the git tree (issue #14).
+# When set and --out-dir is omitted, collector writes to $PROMETHEUS_DATA_ROOT/raw/<owner_repo>/.
 # export PROMETHEUS_DATA_ROOT=~/rmems/prometheus-data
 
-# Issue #5 — collect raw PR records (gitignored under datasets/raw/, or $PROMETHEUS_DATA_ROOT/raw/)
+# Issue #5 — collect raw PR records (default: datasets/raw/<owner_repo>/, or DATA_ROOT)
 python scripts/collect_pr_records.py \
   --repo rmems/corinth-canal \
-  --pr 82,89,91,94,95,96 \
-  --out-dir datasets/raw/corinth-canal
+  --pr 82,89,91,94,95,96
+
+# Explicit in-tree path (overrides PROMETHEUS_DATA_ROOT):
+#   --out-dir datasets/raw/corinth-canal
 
 # Issue #6 — normalize to schema-compliant JSONL
 python scripts/build_trajectory_jsonl.py \

--- a/README.md
+++ b/README.md
@@ -79,7 +79,10 @@ pip install -r requirements.txt
 
 export GITHUB_TOKEN=...   # optional; higher rate limits
 
-# Issue #5 — collect raw PR records (gitignored under datasets/raw/)
+# Optional: large raw dumps outside the git tree (issue #14)
+# export PROMETHEUS_DATA_ROOT=~/rmems/prometheus-data
+
+# Issue #5 — collect raw PR records (gitignored under datasets/raw/, or $PROMETHEUS_DATA_ROOT/raw/)
 python scripts/collect_pr_records.py \
   --repo rmems/corinth-canal \
   --pr 82,89,91,94,95,96 \

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # STATUS — Operation Prometheus
 
-**Last updated:** 2026-08-02  
+**Last updated:** 2026-08-11  
 **By:** Grok Build Agent: Grok 4.5 (xAI)
 
 ## Accomplished this sprint
@@ -26,7 +26,7 @@
 ## Remaining gaps
 
 - Schema v0 lacks `training_use: feature` (mapped to `other`)  
-- **#14** sibling data root for large patches not yet documented as env default  
+- **#14** sibling data root — implemented on `feat/issue-14-prometheus-data-root` (`PROMETHEUS_DATA_ROOT`, `--skip-existing`, `list_merged_prs.py`); package version **0.4.0**  
 - Later Limen waves (neuromod, SpikeStream, kinetic-signals, limbic-critic) not extracted  
 - Large patches still truncated; bot review noise high on Limen PRs  
 - Manual human re-inspection sample still recommended before training runs  
@@ -34,7 +34,7 @@
 ## Next-sprint roadmap (prioritized)
 
 1. **Review-signal dedupe** (#18) + **`language_by_pr`** (#19) — both block grok-ozempic#42 (#20)  
-2. **Sibling data root** (#14) — `PROMETHEUS_DATA_ROOT` for raw/full patches  
+2. **Sibling data root** (#14) — PR in progress (`feat/issue-14-prometheus-data-root`)  
 3. **Limen Wave B** — neuromod #5/#8/#9 or SpikeStream #22/#25  
 4. **Schema v0.1** — add `feature` to `training_use`  
 5. **SFT export adapter** — JSONL → chat/process-supervision pairs  

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -12,7 +12,7 @@ This directory contains generated artifacts for Operation Prometheus trajectory 
 
 Large data should live outside the repo (e.g. on object storage, Dolt, or a separate private datasets repo) and be referenced via manifests or cards.
 
-### Sibling data root (`PROMETHEUS_DATA_ROOT`)
+## Sibling data root (`PROMETHEUS_DATA_ROOT`)
 
 For scale collects, set a sibling directory so raw dumps never bloat the git tree:
 

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -12,6 +12,22 @@ This directory contains generated artifacts for Operation Prometheus trajectory 
 
 Large data should live outside the repo (e.g. on object storage, Dolt, or a separate private datasets repo) and be referenced via manifests or cards.
 
+### Sibling data root (`PROMETHEUS_DATA_ROOT`)
+
+For scale collects, set a sibling directory so raw dumps never bloat the git tree:
+
+```bash
+export PROMETHEUS_DATA_ROOT=~/rmems/prometheus-data   # or /tmp/prometheus-data
+# Layout:
+#   $PROMETHEUS_DATA_ROOT/raw/<owner_repo>/pr-N.json
+```
+
+When `PROMETHEUS_DATA_ROOT` is set and `--out-dir` is omitted, `collect_pr_records.py` writes under that root. Resume multi-hour batches with `--skip-existing`. Discover candidates with `scripts/list_merged_prs.py` (still shortlist before training).
+
+| Commit | Do not commit |
+|--------|----------------|
+| cards, manifests, small curated JSONL, examples | `$PROMETHEUS_DATA_ROOT/**`, full multi-MB JSONL regenerates |
+
 This keeps the repository small, inspectable, and compliant with the project's prime directive and "Do Not" guidelines.
 
 See:

--- a/docs/data-policy.md
+++ b/docs/data-policy.md
@@ -36,6 +36,8 @@ Raw GitHub API exports (issues.jsonl, prs.jsonl, etc.) are treated as **temporar
 
 Large raw exports should live outside the repo (local disk, object storage, or a private datasets mirror) and are gitignored by default.
 
+Preferred local layout for scale: set **`PROMETHEUS_DATA_ROOT`** (e.g. `~/rmems/prometheus-data`) so the collector writes `raw/<owner_repo>/pr-N.json` outside the git tree. See [datasets/README.md](../datasets/README.md).
+
 ## Manual Inspection Requirement
 
 Before any generated dataset is published or used for training:

--- a/scripts/collect_pr_records.py
+++ b/scripts/collect_pr_records.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
 """Read-only GitHub PR collector for Operation Prometheus.
 
-Collects public PR trajectory signals into local JSON under datasets/raw/.
-Performs no write operations against GitHub.
+Collects public PR trajectory signals into local JSON under datasets/raw/
+(or $PROMETHEUS_DATA_ROOT/raw/ when set). Performs no write operations against GitHub.
 
 Examples:
-    export GITHUB_TOKEN=...
+    export GITHUB_TOKEN="$(gh auth token)"
     python scripts/collect_pr_records.py \\
       --repo rmems/corinth-canal --pr 89 \\
       --out-dir datasets/raw/corinth-canal
 
+    export PROMETHEUS_DATA_ROOT=~/rmems/prometheus-data
     python scripts/collect_pr_records.py \\
-      --repo rmems/corinth-canal --pr 82,89,91,94,95,96 \\
-      --out-dir datasets/raw/corinth-canal
+      --repo Limen-Neural/neuromod --pr 5,8,9 --skip-existing
 """
 
 from __future__ import annotations
@@ -27,7 +27,8 @@ _SCRIPTS = Path(__file__).resolve().parent
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
-from lib.github_client import GitHubClient, GitHubError, parse_repo, repo_slug  # noqa: E402
+from lib.github_client import GitHubClient, GitHubError, parse_repo  # noqa: E402
+from lib.paths import DATA_ROOT_ENV, resolve_raw_out_dir  # noqa: E402
 from lib.raw_record import collect_pr, write_raw_record  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -60,7 +61,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--out-dir",
         type=Path,
         default=None,
-        help="Output directory (default: datasets/raw/<repo-slug>)",
+        help=(
+            "Output directory. Default: $"
+            + DATA_ROOT_ENV
+            + "/raw/<owner_repo> if set, else datasets/raw/<owner_repo>"
+        ),
     )
     p.add_argument(
         "--token-env",
@@ -75,6 +80,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--skip-checks", action="store_true", help="Skip check-runs API")
     p.add_argument("--skip-diff", action="store_true", help="Skip full unified diff fetch")
+    p.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help="Skip PRs that already have pr-N.json in out-dir (resume-friendly)",
+    )
     p.add_argument(
         "--allow-cross-repo",
         action="append",
@@ -108,18 +118,24 @@ def main(argv: list[str] | None = None) -> int:
         logger.error("%s", exc)
         return 2
 
-    out_dir = args.out_dir
-    if out_dir is None:
-        root = Path(__file__).resolve().parent.parent
-        out_dir = root / "datasets" / "raw" / repo_slug(full)
+    out_dir = resolve_raw_out_dir(full, args.out_dir)
 
     if args.dry_run:
         print(f"Would collect {full} PRs {prs} → {out_dir}")
+        if args.skip_existing:
+            print("(with --skip-existing)")
         return 0
 
     client = GitHubClient.from_env(args.token_env)
     failures = 0
+    collected = 0
+    skipped = 0
     for pr in prs:
+        target = out_dir / f"pr-{pr}.json"
+        if args.skip_existing and target.exists():
+            logger.info("Skipping %s#%s (exists: %s)", full, pr, target)
+            skipped += 1
+            continue
         logger.info("Collecting %s#%s …", full, pr)
         try:
             record = collect_pr(
@@ -136,6 +152,7 @@ def main(argv: list[str] | None = None) -> int:
                 max_inline_diff_bytes=args.max_inline_diff_bytes,
             )
             logger.info("Wrote %s", path)
+            collected += 1
         except (GitHubError, OSError, ValueError) as exc:
             failures += 1
             logger.error("Failed %s#%s: %s", full, pr, exc)
@@ -143,9 +160,19 @@ def main(argv: list[str] | None = None) -> int:
                 return 1
 
     if failures:
-        logger.error("%s PR(s) failed", failures)
+        logger.error(
+            "%s PR(s) failed (%s collected, %s skipped)",
+            failures,
+            collected,
+            skipped,
+        )
         return 1
-    logger.info("Collected %s PR(s) into %s", len(prs), out_dir)
+    logger.info(
+        "Done: %s collected, %s skipped → %s",
+        collected,
+        skipped,
+        out_dir,
+    )
     return 0
 
 

--- a/scripts/lib/__init__.py
+++ b/scripts/lib/__init__.py
@@ -1,3 +1,3 @@
 """Shared library for Operation Prometheus PR collection and normalization."""
 
-__version__ = "0.1.0"
+__version__ = "0.4.0"

--- a/scripts/lib/github_client.py
+++ b/scripts/lib/github_client.py
@@ -54,7 +54,12 @@ class GitHubClient:
 
     @classmethod
     def from_env(cls, env_name: str = "GITHUB_TOKEN") -> GitHubClient:
-        return cls(token=os.environ.get(env_name) or None)
+        """Load token from env. Default name GITHUB_TOKEN; falls back to GH_TOKEN."""
+        token = os.environ.get(env_name) or None
+        if not token and env_name == "GITHUB_TOKEN":
+            # gh CLI commonly exports GH_TOKEN; bridge without printing secrets.
+            token = os.environ.get("GH_TOKEN") or None
+        return cls(token=token)
 
     def _headers(self, accept: str = "application/vnd.github+json") -> dict[str, str]:
         headers = {

--- a/scripts/lib/paths.py
+++ b/scripts/lib/paths.py
@@ -1,0 +1,41 @@
+"""Filesystem layout helpers for collectors (sibling data root support)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from .github_client import repo_slug
+
+# Env var for large raw/full outputs (issue #14). Prefer sibling of the git repo.
+DATA_ROOT_ENV = "PROMETHEUS_DATA_ROOT"
+
+
+def repo_root() -> Path:
+    """operation-prometheus repository root (parent of scripts/)."""
+    return Path(__file__).resolve().parent.parent.parent
+
+
+def data_root_from_env() -> Path | None:
+    """Return PROMETHEUS_DATA_ROOT if set and non-empty, else None."""
+    raw = (os.environ.get(DATA_ROOT_ENV) or "").strip()
+    if not raw:
+        return None
+    return Path(raw).expanduser().resolve()
+
+
+def resolve_raw_out_dir(repo: str, out_dir: Path | None = None) -> Path:
+    """Resolve directory for pr-N.json raw records.
+
+    Priority:
+    1. Explicit ``out_dir`` argument
+    2. ``$PROMETHEUS_DATA_ROOT/raw/<owner_repo>`` when env is set
+    3. ``<repo>/datasets/raw/<owner_repo>`` (in-tree gitignored default)
+    """
+    if out_dir is not None:
+        return Path(out_dir)
+    slug = repo_slug(repo)
+    root = data_root_from_env()
+    if root is not None:
+        return root / "raw" / slug
+    return repo_root() / "datasets" / "raw" / slug

--- a/scripts/list_merged_prs.py
+++ b/scripts/list_merged_prs.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """List merged public PRs for a repository (discovery helper for scale waves).
 
-Read-only. Prints PR numbers and a compact JSON summary to stdout.
+Read-only. Default output is a human table plus a ``# numbers:`` line.
+Use ``--json`` for a JSON array, or ``--numbers-only`` for a comma-separated list.
 
 Examples:
     export GITHUB_TOKEN="$(gh auth token)"
@@ -36,6 +37,8 @@ def list_merged_prs(
     per_page: int = 100,
 ) -> list[dict[str, Any]]:
     """Return up to ``limit`` merged PR summaries (newest first by update time)."""
+    if limit < 1:
+        raise ValueError("limit must be >= 1")
     owner, name = parse_repo(repo)
     full = f"{owner}/{name}"
     path = f"/repos/{full}/pulls?state=closed&sort=updated&direction=desc"
@@ -46,9 +49,12 @@ def list_merged_prs(
                 continue
             if not pr.get("merged_at"):
                 continue
+            num = pr.get("number")
+            if num is None:
+                continue
             found.append(
                 {
-                    "number": pr.get("number"),
+                    "number": num,
                     "title": pr.get("title") or "",
                     "merged_at": pr.get("merged_at"),
                     "user": ((pr.get("user") or {}).get("login")),
@@ -87,7 +93,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--json",
         action="store_true",
-        help="Print full JSON array (default is human table + trailing JSON)",
+        help="Print full JSON array (default is human table + # numbers: line)",
     )
     return p
 
@@ -111,7 +117,9 @@ def main(argv: list[str] | None = None) -> int:
         logger.error("%s", exc)
         return 1
 
-    numbers = [int(i["number"]) for i in items if i.get("number") is not None]
+    numbers = [
+        int(i["number"]) for i in items if "number" in i and i["number"] is not None
+    ]
     if args.numbers_only:
         print(",".join(str(n) for n in numbers))
         return 0

--- a/scripts/list_merged_prs.py
+++ b/scripts/list_merged_prs.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""List merged public PRs for a repository (discovery helper for scale waves).
+
+Read-only. Prints PR numbers and a compact JSON summary to stdout.
+
+Examples:
+    export GITHUB_TOKEN="$(gh auth token)"
+    python scripts/list_merged_prs.py --repo Limen-Neural/neuromod --limit 30
+    python scripts/list_merged_prs.py --repo rmems/corinth-canal --limit 10 --numbers-only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+_SCRIPTS = Path(__file__).resolve().parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from lib.github_client import GitHubClient, GitHubError, parse_repo  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger("list_merged_prs")
+
+
+def list_merged_prs(
+    client: GitHubClient,
+    repo: str,
+    *,
+    limit: int = 50,
+    per_page: int = 100,
+) -> list[dict[str, Any]]:
+    """Return up to ``limit`` merged PR summaries (newest first by update time)."""
+    owner, name = parse_repo(repo)
+    full = f"{owner}/{name}"
+    path = f"/repos/{full}/pulls?state=closed&sort=updated&direction=desc"
+    found: list[dict[str, Any]] = []
+    for page in client.paginate(path, per_page=per_page):
+        for pr in page:
+            if not isinstance(pr, dict):
+                continue
+            if not pr.get("merged_at"):
+                continue
+            found.append(
+                {
+                    "number": pr.get("number"),
+                    "title": pr.get("title") or "",
+                    "merged_at": pr.get("merged_at"),
+                    "user": ((pr.get("user") or {}).get("login")),
+                    "html_url": pr.get("html_url"),
+                    "additions": pr.get("additions"),
+                    "deletions": pr.get("deletions"),
+                    "changed_files": pr.get("changed_files"),
+                }
+            )
+            if len(found) >= limit:
+                return found
+        if not page:
+            break
+    return found
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--repo", required=True, help="GitHub repository owner/name")
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Max merged PRs to return (default 50)",
+    )
+    p.add_argument(
+        "--token-env",
+        default="GITHUB_TOKEN",
+        help="Env var for GitHub token (default GITHUB_TOKEN; also tries GH_TOKEN)",
+    )
+    p.add_argument(
+        "--numbers-only",
+        action="store_true",
+        help="Print comma-separated PR numbers only (for piping into collect)",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Print full JSON array (default is human table + trailing JSON)",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        owner, name = parse_repo(args.repo)
+        full = f"{owner}/{name}"
+    except ValueError as exc:
+        logger.error("%s", exc)
+        return 2
+    if args.limit < 1:
+        logger.error("--limit must be >= 1")
+        return 2
+
+    client = GitHubClient.from_env(args.token_env)
+    try:
+        items = list_merged_prs(client, full, limit=args.limit)
+    except GitHubError as exc:
+        logger.error("%s", exc)
+        return 1
+
+    numbers = [int(i["number"]) for i in items if i.get("number") is not None]
+    if args.numbers_only:
+        print(",".join(str(n) for n in numbers))
+        return 0
+    if args.json:
+        print(json.dumps(items, indent=2))
+        return 0
+
+    print(f"# {full}: {len(items)} merged PR(s) (limit={args.limit})")
+    for i in items:
+        print(
+            f"  #{i['number']:>4}  {i.get('merged_at', '')[:10]}  "
+            f"{(i.get('title') or '')[:72]}"
+        )
+    print(f"# numbers: {','.join(str(n) for n in numbers)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_paths_and_scale.py
+++ b/tests/test_paths_and_scale.py
@@ -1,0 +1,126 @@
+"""Unit tests for PROMETHEUS_DATA_ROOT paths and scale CLI helpers."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from lib.paths import DATA_ROOT_ENV, data_root_from_env, resolve_raw_out_dir  # noqa: E402
+from list_merged_prs import list_merged_prs  # noqa: E402
+import collect_pr_records as collect_mod  # noqa: E402
+
+
+def test_resolve_raw_out_dir_explicit(tmp_path: Path):
+    out = resolve_raw_out_dir("rmems/corinth-canal", tmp_path / "custom")
+    assert out == tmp_path / "custom"
+
+
+def test_resolve_raw_out_dir_data_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setenv(DATA_ROOT_ENV, str(tmp_path / "pdata"))
+    out = resolve_raw_out_dir("Limen-Neural/neuromod", None)
+    assert out == (tmp_path / "pdata").resolve() / "raw" / "Limen-Neural_neuromod"
+
+
+def test_resolve_raw_out_dir_in_tree_default(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(DATA_ROOT_ENV, raising=False)
+    out = resolve_raw_out_dir("rmems/corinth-canal", None)
+    assert out.name == "rmems_corinth-canal"
+    assert out.parent.name == "raw"
+    assert "operation-prometheus" in str(out)
+
+
+def test_data_root_from_env_empty(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(DATA_ROOT_ENV, raising=False)
+    assert data_root_from_env() is None
+    monkeypatch.setenv(DATA_ROOT_ENV, "  ")
+    assert data_root_from_env() is None
+
+
+def test_collect_skip_existing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """--skip-existing does not call GitHub when pr-N.json already exists."""
+    out = tmp_path / "raw"
+    out.mkdir()
+    (out / "pr-89.json").write_text('{"source":{"pr_number":89}}', encoding="utf-8")
+
+    called: list[int] = []
+
+    def fake_collect_pr(client, repo, pr, **kwargs):  # noqa: ANN001
+        called.append(pr)
+        return {
+            "source": {"pr_number": pr, "repo": repo},
+            "diff": {"inline": "", "bytes": 0},
+        }
+
+    def fake_write(record, out_dir, **kwargs):  # noqa: ANN001
+        path = out_dir / f"pr-{record['source']['pr_number']}.json"
+        path.write_text(json.dumps(record), encoding="utf-8")
+        return path
+
+    class DummyClient:
+        pass
+
+    monkeypatch.setattr(collect_mod, "collect_pr", fake_collect_pr)
+    monkeypatch.setattr(collect_mod, "write_raw_record", fake_write)
+    monkeypatch.setattr(
+        collect_mod.GitHubClient,
+        "from_env",
+        classmethod(lambda cls, env_name="GITHUB_TOKEN": DummyClient()),
+    )
+
+    rc = collect_mod.main(
+        [
+            "--repo",
+            "rmems/corinth-canal",
+            "--pr",
+            "89,91",
+            "--out-dir",
+            str(out),
+            "--skip-existing",
+        ]
+    )
+    assert rc == 0
+    assert called == [91]
+    assert (out / "pr-91.json").exists()
+
+
+def test_list_merged_prs_filters_unmerged():
+    class FakeClient:
+        def paginate(self, path: str, *, per_page: int = 100):
+            yield [
+                {
+                    "number": 1,
+                    "title": "closed no merge",
+                    "merged_at": None,
+                    "user": {"login": "a"},
+                    "html_url": "https://example/1",
+                },
+                {
+                    "number": 2,
+                    "title": "merged",
+                    "merged_at": "2026-01-01T00:00:00Z",
+                    "user": {"login": "b"},
+                    "html_url": "https://example/2",
+                    "additions": 1,
+                    "deletions": 0,
+                    "changed_files": 1,
+                },
+            ]
+
+    items = list_merged_prs(FakeClient(), "rmems/corinth-canal", limit=10)
+    assert len(items) == 1
+    assert items[0]["number"] == 2
+
+
+def test_github_client_falls_back_to_gh_token(monkeypatch: pytest.MonkeyPatch):
+    from lib.github_client import GitHubClient
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN", "gh-fallback-token")
+    client = GitHubClient.from_env("GITHUB_TOKEN")
+    assert client.token == "gh-fallback-token"

--- a/tests/test_paths_and_scale.py
+++ b/tests/test_paths_and_scale.py
@@ -126,6 +126,16 @@ def test_list_merged_prs_rejects_nonpositive_limit():
         list_merged_prs(FakeClient(), "rmems/corinth-canal", limit=0)
 
 
+def test_list_merged_prs_cli_limit_zero_exits_2():
+    """CLI --limit 0 must fail before any GitHub call (exit 2)."""
+    import list_merged_prs as list_mod
+
+    rc = list_mod.main(
+        ["--repo", "rmems/corinth-canal", "--limit", "0"]
+    )
+    assert rc == 2
+
+
 def test_github_client_falls_back_to_gh_token(monkeypatch: pytest.MonkeyPatch):
     from lib.github_client import GitHubClient
 

--- a/tests/test_paths_and_scale.py
+++ b/tests/test_paths_and_scale.py
@@ -117,6 +117,15 @@ def test_list_merged_prs_filters_unmerged():
     assert items[0]["number"] == 2
 
 
+def test_list_merged_prs_rejects_nonpositive_limit():
+    class FakeClient:
+        def paginate(self, path: str, *, per_page: int = 100):
+            yield []
+
+    with pytest.raises(ValueError, match="limit"):
+        list_merged_prs(FakeClient(), "rmems/corinth-canal", limit=0)
+
+
 def test_github_client_falls_back_to_gh_token(monkeypatch: pytest.MonkeyPatch):
     from lib.github_client import GitHubClient
 


### PR DESCRIPTION
## Summary

Implements **#14** (sibling data root for large raw/full PR dumps) and starts the **v0.4** package line.

- **`PROMETHEUS_DATA_ROOT`**: when set and `--out-dir` is omitted, collector writes to `$PROMETHEUS_DATA_ROOT/raw/<owner_repo>/pr-N.json`
- **`--skip-existing`**: resume-friendly batch collects
- **`scripts/list_merged_prs.py`**: read-only discovery of merged PRs (shortlists still required)
- **`GH_TOKEN` fallback** when `GITHUB_TOKEN` is unset
- Docs: `datasets/README.md` layout + commit table; `docs/data-policy.md`; README collect note
- Package version **`0.1.0` → `0.4.0`** (`scripts/lib/__init__.py`), aligned with milestone *v0.4 Scale extracts + data root*
- Tests: `tests/test_paths_and_scale.py` (83 total tests green)

Linear: [RM-171](https://linear.app/rpd-34/issue/RM-171)

## Version / tags

Repo had **no git tags** and a stale `__version__` of `0.1.0` while product milestones were already at v0.4. After this merges we will tag **`v0.4.0`**. Retroactive tags for closed milestones (`v0.1.0`–`v0.3.1`) are being pushed separately on main history.

## Test plan

- [x] `ruff check scripts/`
- [x] `pytest -q` (83 passed)
- [x] `python scripts/validate_jsonl.py --strict-policy datasets/jsonl/*.jsonl`
- [x] Live probe: collect neuromod #5/#8/#9 under `/tmp/prometheus-data-tier4` with DATA_ROOT + `--skip-existing` resume

Closes #14

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a sibling data root for large raw PR dumps and scale-friendly collect helpers. Implements Linear RM-171 by defaulting writes to $PROMETHEUS_DATA_ROOT/raw/<owner_repo>/pr-N.json and enabling resume with --skip-existing; also hardens the discovery helper, updates docs, and adds a CLI contract test.

- **New Features**
  - PROMETHEUS_DATA_ROOT: default out-dir when --out-dir is omitted ($PROMETHEUS_DATA_ROOT/raw/<owner_repo>/pr-N.json).
  - --skip-existing in scripts/collect_pr_records.py to resume batches.
  - scripts/list_merged_prs.py for merged PR discovery (--numbers-only and --json supported).
  - Auth fallback to GH_TOKEN when GITHUB_TOKEN is unset; version 0.4.0; docs updated; tests cover path resolution, --skip-existing, token fallback, --limit validation, and that list_merged_prs CLI exits 2 on --limit 0 before any GitHub call.

- **Bug Fixes**
  - Validate --limit and harden number extraction in scripts/list_merged_prs.py; align docs with default human table output.
  - Fix README PROMETHEUS_DATA_ROOT example and a heading level.

<sup>Written for commit 590f020b91cb097e3e5750c40ba65b660d15963a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/operation-prometheus/pull/22?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

