### PR TITLE
fix(normalize): review_signals dedupe + language_by_pr (#18, #19)

### DIFF
--- a/scripts/lib/normalize.py
+++ b/scripts/lib/normalize.py
@@ -334,6 +334,15 @@ _BARE_FIXED_IN_REPLY = re.compile(
     r"(?is)^\s*(?:\*\*)?(?:addressed|fixed)\s+in\s+`?[0-9a-f]{7,40}`?"
     r"(?:\*\*)?\s*\.?\s*$"
 )
+# Ack-shaped replies that may still carry fix rationale after the SHA.
+_ACK_SHAPED_PREFIX = re.compile(
+    r"(?is)^\s*(?:\*\*)?(?:addressed|fixed)\s+in\s+(?:commit\s+)?`?[0-9a-f]{7,40}`?"
+)
+# Leading ack prefix stripped for dedupe keys (issue #18).
+_ACK_PREFIX_FOR_KEY = re.compile(
+    r"(?is)^(?:\*\*)?(?:addressed|fixed)\s+in\s+(?:commit\s+)?`?[0-9a-f]{7,40}`?"
+    r"(?:\*\*)?\s*:?\s*"
+)
 
 
 def _is_non_actionable_review_body(body: str) -> bool:
@@ -348,8 +357,100 @@ def _is_non_actionable_review_body(body: str) -> bool:
     return False
 
 
+def _is_ack_shaped_review_body(body: str) -> bool:
+    """True when the body starts as an Addressed/Fixed-in-SHA ack (may have rationale)."""
+    return bool(body and _ACK_SHAPED_PREFIX.match(body.strip()))
+
+
+def _signal_body_key(body: str) -> str:
+    """Normalize body for dedupe: collapse whitespace, strip leading ack prefix."""
+    text = re.sub(r"\s+", " ", (body or "").strip())
+    text = _ACK_PREFIX_FOR_KEY.sub("", text, count=1)
+    return text.strip().lower()
+
+
+def _select_deduped_signals(
+    candidates: list[dict[str, Any]],
+    *,
+    max_items: int,
+) -> list[dict[str, str]]:
+    """Dedupe by body key; prefer problem statements over acks; keep one ack if useful.
+
+    Implements GH #18: identical multi-thread acks must not fill all slots.
+    """
+    if max_items < 1 or not candidates:
+        return []
+
+    # Preserve first-seen order; if same key appears as both ack and problem, keep problem.
+    by_key: dict[str, dict[str, Any]] = {}
+    order: list[str] = []
+    for c in candidates:
+        key = c["key"]
+        if key not in by_key:
+            by_key[key] = c
+            order.append(key)
+            continue
+        prev = by_key[key]
+        if prev.get("ack") and not c.get("ack"):
+            by_key[key] = c
+
+    problems = [by_key[k] for k in order if not by_key[k].get("ack")]
+    acks = [by_key[k] for k in order if by_key[k].get("ack")]
+
+    selected: list[dict[str, Any]] = []
+    # Reserve one slot for a rationale-bearing ack when problems would otherwise monopolize.
+    reserve = 1 if acks else 0
+    for p in problems:
+        if len(selected) >= max_items - reserve:
+            break
+        selected.append(p)
+    if acks:
+        if len(selected) < max_items:
+            selected.append(acks[0])
+        for a in acks[1:]:
+            if len(selected) >= max_items:
+                break
+            selected.append(a)
+
+    out: list[dict[str, str]] = []
+    for s in selected[:max_items]:
+        item: dict[str, str] = {
+            "author": str(s.get("author") or "unknown"),
+            "comment": str(s.get("comment") or "")[:2000],
+        }
+        suggestion = s.get("suggestion")
+        if isinstance(suggestion, str) and suggestion.strip():
+            item["suggestion"] = suggestion.strip()[:2000]
+        out.append(item)
+    return out
+
+
 def extract_review_signals(raw: dict[str, Any], *, max_items: int = 8) -> list[dict[str, str]]:
-    signals: list[dict[str, str]] = []
+    """Collect review-shaped comments, dedupe, and rank problems above acks (GH #18)."""
+    candidates: list[dict[str, Any]] = []
+
+    def _push(
+        author: str | None,
+        body: str,
+        *,
+        suggestion: str | None = None,
+    ) -> None:
+        body = (body or "").strip()
+        if not body or _is_non_actionable_review_body(body):
+            return
+        key = _signal_body_key(body)
+        if not key:
+            return
+        entry: dict[str, Any] = {
+            "author": author or "unknown",
+            "comment": body[:2000],
+            "key": key,
+            "ack": _is_ack_shaped_review_body(body),
+        }
+        if suggestion:
+            entry["suggestion"] = suggestion
+        candidates.append(entry)
+
     # Process reviews first to preserve maintainer approve/request-changes signals
     # (including short LGTM / Approved bodies that still carry decision state).
     for r in raw.get("reviews") or []:
@@ -360,69 +461,44 @@ def extract_review_signals(raw: dict[str, Any], *, max_items: int = 8) -> list[d
         if not body or len(body) < 20:
             if state in ("APPROVED", "CHANGES_REQUESTED", "DISMISSED"):
                 if body:
-                    # Keep short human wording (e.g. LGTM) and annotate state.
                     body = f"{body} (review state: {state})"
                 else:
                     body = f"Review state: {state}"
             else:
                 continue
         body, _ = sanitize_text(strip_bot_boilerplate(body))
+        _push(r.get("user_login"), body)
+
+    for c in raw.get("review_comments") or []:
+        if is_bot_user(c.get("user_login"), c.get("user_type")):
+            continue
+        body = strip_bot_boilerplate((c.get("body") or "").strip())
         if not body or _is_non_actionable_review_body(body):
             continue
-        signals.append(
-            {
-                "author": r.get("user_login") or "unknown",
-                "comment": body[:2000],
-            }
-        )
-        if len(signals) >= max_items:
-            break
-    # Then add inline review_comments if space remains
-    if len(signals) < max_items:
-        for c in raw.get("review_comments") or []:
-            if is_bot_user(c.get("user_login"), c.get("user_type")):
-                continue
-            body = strip_bot_boilerplate((c.get("body") or "").strip())
-            if not body or _is_non_actionable_review_body(body):
-                continue
-            body, _ = sanitize_text(body)
-            if not body or _is_non_actionable_review_body(body):
-                continue
-            item: dict[str, str] = {
-                "author": c.get("user_login") or "unknown",
-                "comment": body[:2000],
-            }
-            if "```suggestion" in body:
-                m = re.search(r"```suggestion\s*\n(.*?)```", body, re.DOTALL)
-                if m:
-                    suggestion = m.group(1).strip()[:2000]
-                    # Empty suggestion blocks (delete-line) must not set the field —
-                    # schema requires minLength 1 on suggestion when present.
-                    if suggestion:
-                        item["suggestion"] = suggestion
-            signals.append(item)
-            if len(signals) >= max_items:
-                break
-    # Finally non-bot PR conversation comments (often carry review signal)
-    if len(signals) < max_items:
-        for c in raw.get("issue_comments") or []:
-            if is_bot_user(c.get("user_login"), c.get("user_type")):
-                continue
-            body = strip_bot_boilerplate((c.get("body") or "").strip())
-            if not body or len(body) < 20 or _is_non_actionable_review_body(body):
-                continue
-            body, _ = sanitize_text(body)
-            if not body or _is_non_actionable_review_body(body):
-                continue
-            signals.append(
-                {
-                    "author": c.get("user_login") or "unknown",
-                    "comment": body[:2000],
-                }
-            )
-            if len(signals) >= max_items:
-                break
-    return signals
+        body, _ = sanitize_text(body)
+        if not body or _is_non_actionable_review_body(body):
+            continue
+        suggestion: str | None = None
+        if "```suggestion" in body:
+            m = re.search(r"```suggestion\s*\n(.*?)```", body, re.DOTALL)
+            if m:
+                sug = m.group(1).strip()[:2000]
+                if sug:
+                    suggestion = sug
+        _push(c.get("user_login"), body, suggestion=suggestion)
+
+    for c in raw.get("issue_comments") or []:
+        if is_bot_user(c.get("user_login"), c.get("user_type")):
+            continue
+        body = strip_bot_boilerplate((c.get("body") or "").strip())
+        if not body or len(body) < 20 or _is_non_actionable_review_body(body):
+            continue
+        body, _ = sanitize_text(body)
+        if not body or _is_non_actionable_review_body(body):
+            continue
+        _push(c.get("user_login"), body)
+
+    return _select_deduped_signals(candidates, max_items=max_items)
 
 
 # Negative-test prose. A fixture that is *supposed* to fail, and did, is evidence
@@ -939,6 +1015,18 @@ def outcome_for(raw: dict[str, Any]) -> str:
 
 
 def language_for(card: dict[str, Any], raw: dict[str, Any]) -> str:
+    """Resolve language: language_by_pr → card language → file extensions (GH #19)."""
+    # Per-PR override (keys may be str or int in JSON), same pattern as domain_for.
+    by_pr = card.get("language_by_pr") or {}
+    if by_pr:
+        pr = int((raw.get("source") or {}).get("pr_number") or 0)
+        if pr:
+            for k, v in by_pr.items():
+                try:
+                    if int(k) == pr and isinstance(v, str) and v.strip():
+                        return v.strip()
+                except (TypeError, ValueError):
+                    continue
     if card.get("language"):
         return str(card["language"])
     files = [f.get("filename") or "" for f in (raw.get("files") or [])]

--- a/scripts/lib/normalize.py
+++ b/scripts/lib/normalize.py
@@ -364,10 +364,19 @@ def _is_ack_shaped_review_body(body: str) -> bool:
 
 
 def _signal_body_key(body: str) -> str:
-    """Normalize body for dedupe: collapse whitespace, strip ack prefix + fences."""
+    """Normalize body for dedupe: collapse whitespace, strip ack prefix.
+
+    Only ``suggestion`` fences are removed so a prose review and its inline
+    twin share a key. Other fenced blocks stay part of the signal identity
+    (Bugbot: do not collapse distinct fence-only reviews).
+    """
     text = body or ""
-    # Drop fenced blocks so a review and its inline ```suggestion``` twin share a key.
-    text = re.sub(r"```.*?```", " ", text, flags=re.DOTALL)
+    text = re.sub(
+        r"```suggestion\s*\n.*?```",
+        " ",
+        text,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
     text = re.sub(r"\s+", " ", text.strip())
     text = _ACK_PREFIX_FOR_KEY.sub("", text, count=1)
     key = text.strip().lower()
@@ -453,6 +462,9 @@ def extract_review_signals(raw: dict[str, Any], *, max_items: int = 8) -> list[d
         if not body or _is_non_actionable_review_body(body):
             return
         key = _signal_body_key(body)
+        if not key and suggestion:
+            # Suggestion-only bodies remain valid schema signals.
+            key = "suggestion:" + (_signal_body_key(suggestion) or suggestion.strip().lower()[:120])
         if not key:
             return
         entry: dict[str, Any] = {

--- a/scripts/lib/normalize.py
+++ b/scripts/lib/normalize.py
@@ -330,8 +330,9 @@ def extract_issue_context(raw: dict[str, Any]) -> str | None:
 
 
 # Maintainer ack-only replies consume review-signal budget without review content.
+# Optional "commit" token matches "Fixed in commit <sha>." (Bugbot / GH #18 follow-up).
 _BARE_FIXED_IN_REPLY = re.compile(
-    r"(?is)^\s*(?:\*\*)?(?:addressed|fixed)\s+in\s+`?[0-9a-f]{7,40}`?"
+    r"(?is)^\s*(?:\*\*)?(?:addressed|fixed)\s+in\s+(?:commit\s+)?`?[0-9a-f]{7,40}`?"
     r"(?:\*\*)?\s*\.?\s*$"
 )
 # Ack-shaped replies that may still carry fix rationale after the SHA.
@@ -363,10 +364,17 @@ def _is_ack_shaped_review_body(body: str) -> bool:
 
 
 def _signal_body_key(body: str) -> str:
-    """Normalize body for dedupe: collapse whitespace, strip leading ack prefix."""
-    text = re.sub(r"\s+", " ", (body or "").strip())
+    """Normalize body for dedupe: collapse whitespace, strip ack prefix + fences."""
+    text = body or ""
+    # Drop fenced blocks so a review and its inline ```suggestion``` twin share a key.
+    text = re.sub(r"```.*?```", " ", text, flags=re.DOTALL)
+    text = re.sub(r"\s+", " ", text.strip())
     text = _ACK_PREFIX_FOR_KEY.sub("", text, count=1)
-    return text.strip().lower()
+    key = text.strip().lower()
+    # Empty / punctuation-only after strip is not a usable signal key.
+    if not re.search(r"[a-z0-9]", key):
+        return ""
+    return key
 
 
 def _select_deduped_signals(
@@ -382,24 +390,30 @@ def _select_deduped_signals(
         return []
 
     # Preserve first-seen order; if same key appears as both ack and problem, keep problem.
+    # Merge non-empty suggestion onto the retained candidate when duplicates arrive.
     by_key: dict[str, dict[str, Any]] = {}
     order: list[str] = []
     for c in candidates:
         key = c["key"]
         if key not in by_key:
-            by_key[key] = c
+            by_key[key] = dict(c)
             order.append(key)
             continue
         prev = by_key[key]
         if prev.get("ack") and not c.get("ack"):
-            by_key[key] = c
+            merged = dict(c)
+            if not merged.get("suggestion") and prev.get("suggestion"):
+                merged["suggestion"] = prev["suggestion"]
+            by_key[key] = merged
+        elif not prev.get("suggestion") and c.get("suggestion"):
+            prev["suggestion"] = c["suggestion"]
 
     problems = [by_key[k] for k in order if not by_key[k].get("ack")]
     acks = [by_key[k] for k in order if by_key[k].get("ack")]
 
     selected: list[dict[str, Any]] = []
-    # Reserve one slot for a rationale-bearing ack when problems would otherwise monopolize.
-    reserve = 1 if acks else 0
+    # Reserve an ack slot only when max_items > 1 so a lone slot stays problem-first.
+    reserve = 1 if acks and problems and max_items > 1 else 0
     for p in problems:
         if len(selected) >= max_items - reserve:
             break

--- a/tests/test_collect_and_normalize.py
+++ b/tests/test_collect_and_normalize.py
@@ -471,6 +471,30 @@ def test_duplicate_merges_suggestion_from_inline():
     assert signals[0].get("suggestion") == "fixed_line = True"
 
 
+def test_distinct_non_suggestion_fences_not_collapsed():
+    """Non-suggestion fences remain part of signal identity (Bugbot)."""
+    from lib.normalize import extract_review_signals
+
+    raw = {
+        "reviews": [],
+        "review_comments": [
+            {
+                "user_login": "reviewer-x",
+                "user_type": "User",
+                "body": "Bad pattern here:\n```rust\nlet x = 1;\n```\n",
+            },
+            {
+                "user_login": "reviewer-x",
+                "user_type": "User",
+                "body": "Bad pattern here:\n```rust\nlet x = 2;\n```\n",
+            },
+        ],
+        "issue_comments": [],
+    }
+    signals = extract_review_signals(raw, max_items=8)
+    assert len(signals) == 2
+
+
 def test_fixed_in_commit_bare_ack_dropped():
     from lib.normalize import extract_review_signals
 

--- a/tests/test_collect_and_normalize.py
+++ b/tests/test_collect_and_normalize.py
@@ -415,19 +415,100 @@ def test_review_signal_dedupe_and_ack_deprioritized():
         assert first_problem < first_ack
 
 
+def test_max_items_one_prefers_problem_over_ack():
+    """When max_items=1, do not reserve the only slot for an ack."""
+    from lib.normalize import extract_review_signals
+
+    raw = {
+        "reviews": [],
+        "review_comments": [
+            {
+                "user_login": "rmems",
+                "user_type": "User",
+                "body": (
+                    "Addressed in abcdef0123456789: portable paths and dtype guard notes."
+                ),
+            },
+            {
+                "user_login": "reviewer-x",
+                "user_type": "User",
+                "body": "Finding 1: please validate export path edge case before merge.",
+            },
+        ],
+        "issue_comments": [],
+    }
+    signals = extract_review_signals(raw, max_items=1)
+    assert len(signals) == 1
+    assert signals[0]["comment"].startswith("Finding 1")
+
+
+def test_duplicate_merges_suggestion_from_inline():
+    """Dedupe keeps problem text and merges a later non-empty suggestion."""
+    from lib.normalize import extract_review_signals
+
+    body = "Please fix the dtype KeyError guard in the export path."
+    raw = {
+        "reviews": [
+            {
+                "user_login": "reviewer-x",
+                "user_type": "User",
+                "state": "COMMENTED",
+                "body": body,
+            }
+        ],
+        "review_comments": [
+            {
+                "user_login": "reviewer-x",
+                "user_type": "User",
+                "body": body + "\n```suggestion\nfixed_line = True\n```\n",
+            }
+        ],
+        "issue_comments": [],
+    }
+    signals = extract_review_signals(raw, max_items=8)
+    assert len(signals) == 1
+    assert "dtype KeyError" in signals[0]["comment"]
+    assert signals[0].get("suggestion") == "fixed_line = True"
+
+
+def test_fixed_in_commit_bare_ack_dropped():
+    from lib.normalize import extract_review_signals
+
+    raw = {
+        "reviews": [],
+        "review_comments": [],
+        "issue_comments": [
+            {
+                "user_login": "rmems",
+                "user_type": "User",
+                "body": "Fixed in commit 0b05325abcdef.",
+            },
+            {
+                "user_login": "reviewer-x",
+                "user_type": "User",
+                "body": "Please reject non-finite input_range before division in GainCurve::evaluate.",
+            },
+        ],
+    }
+    signals = extract_review_signals(raw)
+    assert len(signals) == 1
+    assert "GainCurve" in signals[0]["comment"]
+
+
 def test_language_by_pr_overrides_card_language():
     """GH #19: language_by_pr beats card.language for that PR only."""
     from lib.normalize import language_for
 
     card = {
         "language": "Rust",
-        "language_by_pr": {"42": "Python", "99": ""},
+        "language_by_pr": {"42": "Python", 7: "Julia", "99": ""},
     }
     raw42 = {"source": {"pr_number": 42}, "files": [{"filename": "scripts/export.py"}]}
     raw7 = {"source": {"pr_number": 7}, "files": [{"filename": "src/lib.rs"}]}
     raw99 = {"source": {"pr_number": 99}, "files": [{"filename": "src/lib.rs"}]}
     assert language_for(card, raw42) == "Python"
-    assert language_for(card, raw7) == "Rust"
+    # Integer key in language_by_pr
+    assert language_for(card, raw7) == "Julia"
     # Empty override ignored → card language.
     assert language_for(card, raw99) == "Rust"
     # No card language → extension sniff.

--- a/tests/test_collect_and_normalize.py
+++ b/tests/test_collect_and_normalize.py
@@ -367,6 +367,73 @@ def test_bare_fixed_in_replies_not_review_signals():
     assert "GainCurve" in signals[0]["comment"]
 
 
+def test_review_signal_dedupe_and_ack_deprioritized():
+    """GH #18: identical Addressed-in acks must not fill all slots; problems rank first."""
+    from lib.normalize import extract_review_signals
+
+    ack = (
+        "Addressed in 5ecbe0855124d24533a1cc365274ea2dcb9400c1: portable ~/.models "
+        "paths in docs/help (no hard-coded username), dtype KeyError guard, NPY header "
+        "uses space-pad then trailing newline"
+    )
+    raw = {
+        "reviews": [],
+        "review_comments": [
+            {
+                "user_login": "rmems",
+                "user_type": "User",
+                "body": ack,
+            }
+            for _ in range(8)
+        ]
+        + [
+            {
+                "user_login": "reviewer-x",
+                "user_type": "User",
+                "body": f"Finding {i}: please validate export path edge case {i} before merge.",
+            }
+            for i in range(1, 7)
+        ],
+        "issue_comments": [],
+    }
+    signals = extract_review_signals(raw, max_items=8)
+    comments = [s["comment"] for s in signals]
+    # Dedupe: at most one copy of the ack body (or its rationale key).
+    ack_hits = sum(1 for c in comments if "5ecbe0855124d24533a1cc365274ea2dcb9400c1" in c or "portable ~/.models" in c)
+    assert ack_hits <= 1
+    problem_hits = sum(1 for c in comments if c.startswith("Finding "))
+    assert problem_hits >= 5
+    assert len(signals) <= 8
+    # Problems appear before the reserved ack when both are present.
+    if problem_hits and ack_hits:
+        first_ack = next(
+            i
+            for i, c in enumerate(comments)
+            if "portable ~/.models" in c or "5ecbe08" in c
+        )
+        first_problem = next(i for i, c in enumerate(comments) if c.startswith("Finding "))
+        assert first_problem < first_ack
+
+
+def test_language_by_pr_overrides_card_language():
+    """GH #19: language_by_pr beats card.language for that PR only."""
+    from lib.normalize import language_for
+
+    card = {
+        "language": "Rust",
+        "language_by_pr": {"42": "Python", "99": ""},
+    }
+    raw42 = {"source": {"pr_number": 42}, "files": [{"filename": "scripts/export.py"}]}
+    raw7 = {"source": {"pr_number": 7}, "files": [{"filename": "src/lib.rs"}]}
+    raw99 = {"source": {"pr_number": 99}, "files": [{"filename": "src/lib.rs"}]}
+    assert language_for(card, raw42) == "Python"
+    assert language_for(card, raw7) == "Rust"
+    # Empty override ignored → card language.
+    assert language_for(card, raw99) == "Rust"
+    # No card language → extension sniff.
+    assert language_for({}, {"source": {"pr_number": 1}, "files": [{"filename": "a.py"}]}) == "Python"
+
+
 def test_remotes_txt_stripped_from_patch():
     from lib.normalize import extract_patch
 


### PR DESCRIPTION
## Summary

Unblocks clean trajectory quality for **v0.5** (epic #31) and grok-ozempic#42 (#20).

### #18 — `review_signals` dedupe + ack deprioritization
- Normalize body keys (collapse whitespace; strip leading `Addressed in <sha>:` / `Fixed in …`)
- Prefer problem statements over ack-shaped replies when filling the cap
- Keep at most one rationale-bearing ack when problems would fill every slot
- Bare `Fixed in <sha>.` / `Fixed in commit <sha>.` acks still dropped as non-actionable
- Only ` ```suggestion ` fences stripped for dedupe keys (other fences stay distinct)

### #19 — `language_by_pr`
- Mirrors `domain_by_pr`: per-PR override before card `language` and extension sniff
- String/int JSON keys supported

## Development
Closes #18
Closes #19

Parent epic: #31

## Linear
- https://linear.app/rpd-34/issue/RM-224 (#18)
- https://linear.app/rpd-34/issue/RM-225 (#19)
- Epic: https://linear.app/rpd-34/issue/RM-582 (#31)

## Project
[Spartan ML training](https://github.com/users/rmems/projects/8) — Status In review, Priority P0

## Test plan
- [x] `ruff check` + `pytest` (91 tests)
- [x] New tests: ack spam dedupe, max_items=1, suggestion merge, int `language_by_pr`, distinct fences