### PR TITLE
docs: rewrite fleet inventory from live 2026-08 scan (#30)

### DIFF
--- a/docs/source-repos/_index.md
+++ b/docs/source-repos/_index.md
@@ -28,6 +28,9 @@ One record per PR. See [datasets/README.md](../../datasets/README.md) for commit
 | [rmems/grok-ozempic](https://github.com/rmems/grok-ozempic) | [grok-ozempic.md](grok-ozempic.md) | v0 extracted |
 | [Limen-Neural](https://github.com/Limen-Neural) (org) | [limen-neural.md](limen-neural.md) | Wave A extracted (axon-encoder) |
 | [rmems/myelin-accelerator](https://github.com/rmems/myelin-accelerator) | [myelin-accelerator.md](myelin-accelerator.md) | v0 extracted |
+| [rmems/Theseus-Quarry](https://github.com/rmems/Theseus-Quarry) | [theseus-quarry.md](theseus-quarry.md) | shortlist drafted |
+| [rmems (org)](https://github.com/rmems) | [wave-c.md](wave-c.md) | pointers only |
+| [rmems/worktrees-hives](https://github.com/rmems/worktrees-hives) | [worktrees-hives.md](worktrees-hives.md) | shortlist drafted |
 
 <!-- END GENERATED INDEX -->
 
@@ -45,6 +48,18 @@ A PR belongs on a shortlist when it has:
    [`extract_review_signals`](../../scripts/lib/normalize.py) (hard cap `max_items=8`).
 3. **Validation evidence** — CI, tests, or a documented validation ladder.
 4. **Public-only history** — owner access to a private repo does not make it eligible.
+
+## Parked (Tier C)
+
+Repos deliberately **not** being extracted (live scan 2026-08-16). Parked repos have
+no per-repo doc and no index line; unparking one means giving it a doc per
+[Adding New Source Repos](#adding-new-source-repos).
+
+| Repo | Why parked | Revisit when |
+|------|-----------|--------------|
+| [rmems/blackwell-kernel-lab](https://github.com/rmems/blackwell-kernel-lab) | Merged PRs now exist (#22–#28, 2026-08) but are bench/experiment logs, and the repo boundary is in flux — issue #32 wants the agent harness removed ("this repo is CUDA kernels") | Harness split settles and an issue-linked kernel wave merges |
+| Dependabot-dominated repos (e.g. [plasticity-lab](https://github.com/Limen-Neural/plasticity-lab)) | Merge history is dependency-bump noise — nothing survives the [Avoid list](#avoid-for-v0-training) | A non-chore code wave lands |
+| Docs-only / config-only repos | No code delta to learn from (pure-docs exclusion) | They grow reviewed code PRs |
 
 ## Avoid for v0 training
 

--- a/docs/source-repos/corinth-canal.md
+++ b/docs/source-repos/corinth-canal.md
@@ -79,3 +79,30 @@
 - **Why high-signal**: Adds `validate_local_saaq` (dry-run matrix validator with `--check-paths`) and `summarize_local_saaq` (markdown sprint summary from run artifacts). Tools-for-tools trajectory.
 - **Dataset bucket**: `feature` — CLI tooling for experiment validation and reporting
 - **Closes**: rmems/corinth-canal#90 (partial — Lane A + D)
+
+## Candidate next wave (2026-08-16 scan — not extracted)
+
+The v0 shortlist above predates the GH#118 GGUF/Safetensors refactor wave. Live
+merged candidates, with **raw** GitHub API counts (`reviews` / review threads /
+issue comments — *pre* bot-filter; pipeline yield is measured at extraction time):
+
+| PR | Title | Reviews | Threads | Comments | Size | Merged | Closes |
+|----|-------|---------|---------|----------|------|--------|--------|
+| [#125](https://github.com/rmems/corinth-canal/pull/125) | Unify GGUF/Safetensors family inference (GH#118 PR-1) | 81 | 44 | 29 | +1139/−230, 11 files | 2026-07-23 | #133 |
+| [#142](https://github.com/rmems/corinth-canal/pull/142) | Accept dense_sim/stub_uniform in ROUTING_MODE | 33 | 14 | 10 | +139/−23, 3 files | 2026-08-11 | #140 |
+| [#138](https://github.com/rmems/corinth-canal/pull/138) | Recover priority-ordered GGUF synapse source selection (GH#118 PR-2) | 11 | 13 | 19 | +891/−143, 6 files | 2026-08-08 | #134 |
+| [#128](https://github.com/rmems/corinth-canal/pull/128) | Split checkpoint.rs into private gguf/ modules (GH#118 PR-4) | 9 | 6 | 15 | +1329/−1207, 11 files | 2026-07-21 | — |
+| [#127](https://github.com/rmems/corinth-canal/pull/127) | Extract config validation helpers (GH#118 PR-3) | 7 | 2 | 12 | +49/−30, 1 file | 2026-07-22 | #135 |
+| [#126](https://github.com/rmems/corinth-canal/pull/126) | Priority-ordered GGUF synapse source selection (GH#118 PR-2) | 6 | 2 | 20 | +597/−130, 3 files | 2026-07-22 | — |
+
+Notes from the scan:
+
+- `#125` and `#142` carry the strongest review→fix signal; `#125` alone has 81
+  reviews over 16 commits.
+- `#138` is a *recovery* of `#126`'s change (same GH#118 PR-2 label) — the pair is a
+  potential regression→repair trajectory; extract together or prefer `#138`.
+- A newer safetensors module-extraction series (GH#147: [#152](https://github.com/rmems/corinth-canal/pull/152),
+  [#153](https://github.com/rmems/corinth-canal/pull/153), [#154](https://github.com/rmems/corinth-canal/pull/154),
+  merged 2026-08-12/13, reviews 2/10/13) plus [#156](https://github.com/rmems/corinth-canal/pull/156)
+  (GH#116 retarget to engram-parser) landed after this wave — lower measured density,
+  re-check when the next-wave extract is scoped.

--- a/docs/source-repos/grok-ozempic.md
+++ b/docs/source-repos/grok-ozempic.md
@@ -83,3 +83,32 @@ cleanest review→fix trajectory in the repo. Only `#11` reaches the 96 KiB patc
 carries the `# … truncated …` footer; `#24` (77,970 chars) and `#26` (50,149) are complete.
 `#26` is smaller than its raw diff because `.beads/` and `.claude/` agent state is filtered
 out of curated patches — see [`_NOISE_PATCH_DIRS`](../../scripts/lib/normalize.py).
+
+## Candidate next wave (2026-08-16 scan — not extracted)
+
+The v0 extract stops at `#43`. A GOZ1 v2/v3 + expert-remedy wave (`#69`–`#79`) has
+merged since, with heavy Codex/Gemini review→patch traffic. **Raw** GitHub API counts
+(`reviews` / review threads / issue comments — *pre* bot-filter; pipeline yield is
+measured at extraction time):
+
+| PR | Title | Reviews | Threads | Comments | Size | Merged | Closes |
+|----|-------|---------|---------|----------|------|--------|--------|
+| [#74](https://github.com/rmems/grok-ozempic/pull/74) | Expert higher-precision remedies for multi-block residual fidelity | 63 | 33 | 10 | +3714/−77, 9 files | 2026-08-08 | #73 |
+| [#72](https://github.com/rmems/grok-ozempic/pull/72) | Expert-only ternary multi-block residual fidelity | 54 | 32 | 11 | +2422/−3, 7 files | 2026-08-08 | #68 |
+| [#69](https://github.com/rmems/grok-ozempic/pull/69) | GOZ1 v2 persists the per-tensor ternary scale | 40 | 46 | 22 | +1588/−72, 22 files | 2026-08-07 | #65 |
+| [#71](https://github.com/rmems/grok-ozempic/pull/71) | GOZ1 v3 persists the applied per-tensor gif_threshold | 25 | 26 | 12 | +817/−121, 10 files | 2026-08-08 | #66 |
+| [#76](https://github.com/rmems/grok-ozempic/pull/76) | Measure stacked and denser expert remedies | 18 | 44 | 10 | +9059/−38, 22 files | 2026-08-11 | #75 |
+| [#77](https://github.com/rmems/grok-ozempic/pull/77) | Harden co-author hooks (Codex & Muse) + regression tests | 16 | 28 | 9 | +594/−36, 8 files | 2026-08-11 | — |
+| [#79](https://github.com/rmems/grok-ozempic/pull/79) | Harden #75 secondary evidence validation (PR #76 bot review) | 6 | 8 | 8 | +193/−24, 5 files | 2026-08-11 | — |
+
+Notes from the scan:
+
+- `#76` → `#79` is a merged review→patch pair (`#79` exists solely to answer `#76`'s
+  bot review) — extract together, mirroring the `#78`/`#79` pattern in worktrees-hives.
+- Beyond the wave: [#83](https://github.com/rmems/grok-ozempic/pull/83) (INT4 expert
+  middle-ground, **112 reviews / 65 threads** — the highest raw review count in the
+  repo, merged 2026-08-13) and [#86](https://github.com/rmems/grok-ozempic/pull/86)
+  (#85 harness, 37 reviews / 60 threads, merged 2026-08-15) are prime candidates for
+  the wave after this one.
+- `#76`'s +9059 lines are dominated by measurement artifacts — check the
+  [data-policy.md](../data-policy.md) generated-artifact exclusion before extracting.

--- a/docs/source-repos/limen-neural.md
+++ b/docs/source-repos/limen-neural.md
@@ -35,11 +35,22 @@
 
 ## Later waves (pointers only — not extracted)
 
-| Repo | PRs | Notes |
-|------|-----|--------|
-| neuromod | #5, #8, #9 | Feature then repair/generalize; defer #33 CI monster |
-| SpikeStream.jl | #22, #25 | Boundary cut + golden fixtures |
-| kinetic-signals | #2, #6, #17 | VolEstimator → Surprise → deprecation |
-| limbic-critic | #29, #30 | Dep decoupling + surprise semantics |
+> Refreshed from a live scan 2026-08-16 (issue #28 wave B). Review counts are **raw**
+> GitHub API `reviews` totals (pre bot-filter). **Org drift**: `SpikeStream.jl`,
+> `kinetic-signals`, and `limbic-critic` have been **transferred Limen-Neural → rmems**
+> (see kinetic-signals#42 "post-transfer hygiene") — links below point at rmems.
+
+| Repo | Candidate PRs | Notes |
+|------|---------------|--------|
+| [neuromod](https://github.com/Limen-Neural/neuromod) | #5, #8, #9; newer #97 (23 rev), #96 (42 rev), #98 (15 rev) | Repo now past #99. Feature then repair/generalize; defer #33 CI monster; #96–#98 are a release/Docker-CI review chain |
+| [SpikeStream.jl](https://github.com/rmems/SpikeStream.jl) | #22, #25; higher-signal #18 (27 rev), #21 (26 rev), #20 (21 rev) | **Now rmems.** Boundary cut + golden fixtures; #18/#21 out-measure the original pointers |
+| [kinetic-signals](https://github.com/rmems/kinetic-signals) | #2, #6, #17; newer #39 (**109 rev / 49 threads**), #31 (32 rev) | **Now rmems.** #39 (streaming shared_vectors tests) is the densest wave B candidate found in the scan |
+| [limbic-critic](https://github.com/rmems/limbic-critic) | #29 (10 rev), #30 (7 rev) | **Now rmems.** Dep decoupling + surprise semantics; later PRs are docs/REUSE/publish-prep — excluded |
+| [plasticity-lab](https://github.com/Limen-Neural/plasticity-lab) | — | Recent history is Dependabot-dominated (8 of last 8 merged are chores/dep bumps); low priority until a code wave lands |
+| [brainstem-daemon](https://github.com/Limen-Neural/brainstem-daemon) | #8 (**215 rev / 57 threads**), #24 (56 rev), #25 (18 rev) | #8 (resolve issues #4–#7) is the largest raw review count seen org-wide; #24 corpus-ipc decoupling |
+| [synaptic-mesh](https://github.com/Limen-Neural/synaptic-mesh) | #8 (51 rev), #13 (71 rev), #25 (21 rev) | Neuromodulatory router feature + license/CI repair with real review traffic |
+| [nir-rs](https://github.com/Limen-Neural/nir-rs) | #38 (61 rev / 37 threads), #33 (5 rev), #36 (2 rev) | Repo now past #40. #38 Docker dual-publish is the standout; #33–#36 release-gate ladder is thinner than expected |
+
+Full wave B shortlists land when issue #28 is decomposed.
 
 Cross-repo exclusion policy lives in [_index.md](_index.md#avoid-for-v0-training).

--- a/docs/source-repos/theseus-quarry.md
+++ b/docs/source-repos/theseus-quarry.md
@@ -1,0 +1,46 @@
+# Theseus-Quarry
+
+<!-- index: [rmems/Theseus-Quarry](https://github.com/rmems/Theseus-Quarry) | shortlist drafted -->
+
+**Repo**: [rmems/Theseus-Quarry](https://github.com/rmems/Theseus-Quarry)  
+**Description**: Crypto-mining telemetry extraction for neuromorphic-computing research (miner HTTP APIs, JSONL telemetry, GPU signaling)  
+**Language**: Rust  
+**Status**: shortlist **drafted** (2026-08-16 live scan, issue [#30](https://github.com/rmems/operation-prometheus/issues/30)) — not extracted; v0.6 telemetry priority
+
+> Counts below are **raw** GitHub API totals (`reviews` / review threads / issue
+> comments — *pre* bot-filter). Pipeline yield (`is_bot_user` +
+> `extract_review_signals`, cap 8) is measured at extraction time. Small repo:
+> 9 merged PRs total, 7 shortlisted.
+
+## Shortlisted PRs
+
+| PR | Title | Domain | Bucket | Signal |
+|----|-------|--------|--------|--------|
+| [#13](https://github.com/rmems/Theseus-Quarry/pull/13) | Telemetry: Migrate MinerPerf collection to HTTP APIs | telemetry | feature | Densest: 35 reviews / 20 threads; +650/−841 across 14 files — a real migration, not additive. Closes #5. |
+| [#8](https://github.com/rmems/Theseus-Quarry/pull/8) | arch: remove theseus-mining supervisor and migrate gpu_scheduler | telemetry, infra | repair | 28 reviews / 27 threads; −5442-line architectural amputation across 24 files. Closes #3. |
+| [#9](https://github.com/rmems/Theseus-Quarry/pull/9) | Port GPU thermal throttling process signaling to telemetry-collector | telemetry, gpu-compute | feature | 17 reviews / 31 threads, 12 commits; thermal-safety semantics under review. Closes #4. |
+| [#12](https://github.com/rmems/Theseus-Quarry/pull/12) | feat(telemetry): align miner API ports and node RPC endpoints | telemetry, config | repair | 14 reviews / 13 threads across 12 files; endpoint-correctness fix wave. Closes #7. |
+| [#18](https://github.com/rmems/Theseus-Quarry/pull/18) | Telemetry: SRBMiner-Multi HTTP MinerPerf parser | telemetry | feature | 13 reviews; newest merge (2026-08-13), extends the #13 HTTP path to a second miner. Closes #14. |
+| [#11](https://github.com/rmems/Theseus-Quarry/pull/11) | feat(telemetry): implement file rotation for JSONL telemetry | telemetry | feature | 10 reviews / 18 threads on a surgical +46/−26 diff; high thread-to-line ratio. Closes #6. |
+| [#16](https://github.com/rmems/Theseus-Quarry/pull/16) | Quality: Cargo profiles + REVIEW.md | testing, config | validation | 13 reviews; borderline (part config, part docs) — keep only if the extract wants a validation-bucket row. Closes #10. |
+
+## Measured review density (raw, 2026-08-16)
+
+| PR | Reviews | Threads | Comments | Size | Merged | Verdict |
+|----|---------|---------|----------|------|--------|---------|
+| #13 | 35 | 20 | 8 | +650/−841, 14 files | 2026-08-12 | shortlisted |
+| #8 | 28 | 27 | 8 | +71/−5442, 24 files | 2026-08-05 | shortlisted |
+| #9 | 17 | 31 | 18 | +448/−22, 8 files | 2026-08-11 | shortlisted |
+| #12 | 14 | 13 | 6 | +132/−62, 12 files | 2026-08-07 | shortlisted |
+| #18 | 13 | 5 | 5 | +390/−12, 10 files | 2026-08-13 | shortlisted |
+| #16 | 13 | 5 | 6 | +143/−0, 4 files | 2026-08-12 | shortlisted (borderline) |
+| #11 | 10 | 18 | 6 | +46/−26, 4 files | 2026-08-07 | shortlisted |
+
+## Considered and rejected
+
+- **`#1`** (self-hosted Rust + dual Qodana + Docker/devcontainer + qlty + Codacy) —
+  bulk CI-modernization monster without domain signal; excluded under
+  [_index.md](_index.md#avoid-for-v0-training).
+- **`#2`** (fix PR bot findings + Cursor Cloud Docker / AGENTS.md) — mixed
+  bot-finding fixups and agent-config docs; no coherent issue-anchored trajectory.
+- **`#20`** (ownership boundaries docs) — open, unmerged, and docs-only.

--- a/docs/source-repos/wave-c.md
+++ b/docs/source-repos/wave-c.md
@@ -1,0 +1,25 @@
+# rmems wave C (pointers only)
+
+<!-- index: [rmems (org)](https://github.com/rmems) | pointers only -->
+
+**Org**: [rmems](https://github.com/rmems) — wave C source repos from issue
+[#29](https://github.com/rmems/operation-prometheus/issues/29).  
+**Status**: **pointers only** (2026-08-16 live scan) — no shortlists, no extraction.
+Full per-repo shortlists land when [#29](https://github.com/rmems/operation-prometheus/issues/29)
+is decomposed; a wave C repo then graduates to its own `docs/source-repos/<repo>.md`.
+
+> Review counts are **raw** GitHub API `reviews` totals (pre bot-filter), from the
+> most recent 8 merged PRs per repo — older history is unscanned. Several repos were
+> transferred **Limen-Neural → rmems** in 2026-08 ("post-transfer hygiene" PRs);
+> all links below already point at rmems.
+
+| Repo | Candidate PRs | Note |
+|------|---------------|------|
+| [xai-dissect](https://github.com/rmems/xai-dissect) | #48 (**137 rev / 200 threads**), #37 (50 rev), #50 (37 rev), #32 (23 rev) | Rust. #48 is a CI-modernization monster — screen against the [bulk-CI exclusion](_index.md#avoid-for-v0-training) despite the density; #32 export contract is the domain anchor for grok-ozempic. |
+| [engram-parser](https://github.com/rmems/engram-parser) | #44 (GGUF v3 parser + IQ wire layouts), #57 (reverses #10; 8 threads), #23, #21, #1 | Rust. Recent history is Dependabot-dominated (20+ of 35 merged); the real code wave is #44 and the early #17–#23 ladder. corinth-canal#156 retargets its safetensors-inspect half here. |
+| [agoge-forger](https://github.com/rmems/agoge-forger) | #85 (11 rev), #73 (9 rev), #74, #86, #84 | Python (+ Rust tools). Fine-tuning forge; steady issue-linked repair wave (#64–#68 issues), moderate review density. |
+| [spike-viz](https://github.com/rmems/spike-viz) | #22 → #23 (16 rev) review-to-patch pair, #24 (13 rev / 15 threads) | Python. Only 4 merged PRs; #23 exists to answer #22's review — extract as a pair. |
+| [thalamic-relay](https://github.com/rmems/thalamic-relay) | #23 (55 rev), #22 (51 rev), #20 (49 rev / 36 threads), #21 (23 rev) | Rust. GPU-safety supervisor wave #20–#23 is uniformly dense — strongest wave C cluster after xai-dissect. |
+| [LiquidCortex.jl](https://github.com/rmems/LiquidCortex.jl) | #45 (**100 rev / 52 threads**), #32 (19 rev), #31 (10 rev) | Julia. #45 (experimental step plasticity + GPU step options) is a single outlier carrying most of the repo's signal. |
+| [silicon-hdl](https://github.com/rmems/silicon-hdl) | #51 (43 rev), #77 (16 rev), #52 (12 rev), #78 (8 rev / 17 threads) | SystemVerilog — would be the dataset's first HDL language; #51/#52 INIT_FILE E1/E2 pair, #78 gated LIF/STDP merged 2026-08-16. |
+| [hybrid-fusion](https://github.com/rmems/hybrid-fusion) | #19 (27 rev), #17 (17 rev), #16 (14 rev), #30–#32 API-contract wave | Rust. Older test/feature PRs out-measure the newer contract wave (#30–#32, ≤6 rev each). |

--- a/docs/source-repos/worktrees-hives.md
+++ b/docs/source-repos/worktrees-hives.md
@@ -1,0 +1,54 @@
+# worktrees-hives
+
+<!-- index: [rmems/worktrees-hives](https://github.com/rmems/worktrees-hives) | shortlist drafted -->
+
+**Repo**: [rmems/worktrees-hives](https://github.com/rmems/worktrees-hives)  
+**Description**: Multi-agent hypothesis lab — agents/subagents in isolated git worktrees, mandatory JSON + Markdown findings, Python/Rust hybrid safety cage, never auto-merges  
+**Language**: Python (+ Rust `wh-core`)  
+**Status**: shortlist **drafted** (2026-08-16 live scan, issue [#30](https://github.com/rmems/operation-prometheus/issues/30)) — not extracted; v0.6 agentic-workflow priority
+
+> Counts below are **raw** GitHub API totals (`reviews` / review threads / issue
+> comments — *pre* bot-filter). Pipeline yield (`is_bot_user` +
+> `extract_review_signals`, cap 8) is measured at extraction time.
+
+## Shortlisted PRs
+
+| PR | Title | Domain | Bucket | Signal |
+|----|-------|--------|--------|--------|
+| [#61](https://github.com/rmems/worktrees-hives/pull/61) | Issue #6: Claim issue → branch → worktree isolation | agentic-workflow | feature | Densest PR in the repo: 80 reviews / 90 threads on +644 lines. Closes #6. |
+| [#65](https://github.com/rmems/worktrees-hives/pull/65) | Foundation: R1–R3, R5, P1, H1, H3 (hybrid docs + Rust core + Python bridge) | agentic-workflow, ml-infra | feature | 60 reviews / 85 threads; +1736/−57 across 22 files; the hybrid-architecture cut. Closes #24. |
+| [#63](https://github.com/rmems/worktrees-hives/pull/63) | Issue #8: Issue → PR workflow (never auto-merge) | agentic-workflow | feature | 53 reviews / 40 threads on +1221 lines; safety-invariant design under review. Closes #8. |
+| [#78](https://github.com/rmems/worktrees-hives/pull/78) | Wire discover/plan/babysit into the CLI | agentic-workflow, tools | review-to-patch | 24 reviews / 19 threads, 12 commits; paired with follow-up #79. Closes #76. |
+| [#79](https://github.com/rmems/worktrees-hives/pull/79) | fix(cli): address CodeAnt/CodeRabbit review comments on PR #78 | agentic-workflow, tools | review-to-patch | Merged patch answering #78's bot review — extract as a pair with #78. |
+| [#90](https://github.com/rmems/worktrees-hives/pull/90) | feat(python): lab run CLI single hypothesis unit | agentic-workflow | feature | 24 reviews / **62 threads**, 10 commits; heaviest thread traffic of the lab-CLI wave. Closes #80. |
+| [#88](https://github.com/rmems/worktrees-hives/pull/88) | feat(python): lab findings JSON + Markdown contract | agentic-workflow, api | feature | 15 reviews / 10 threads; contract design (+764 lines, all-new). Closes #82. |
+| [#103](https://github.com/rmems/worktrees-hives/pull/103) | feat(python): add Research Hive experiment contract | agentic-workflow, api | feature | 13 reviews on +932 lines; newest contract layer (merged 2026-08-13). Closes #92. |
+| [#105](https://github.com/rmems/worktrees-hives/pull/105) | feat(python): aggregate discoveries report format (Markdown + table) | agentic-workflow, tools | feature | 10 reviews / 16 threads; freshest merge in the repo (2026-08-17 UTC). Closes #16. |
+
+## Measured review density (raw, 2026-08-16)
+
+| PR | Reviews | Threads | Comments | Size | Merged | Verdict |
+|----|---------|---------|----------|------|--------|---------|
+| #61 | 80 | 90 | 25 | +644/−0, 3 files | 2026-07-22 | shortlisted |
+| #65 | 60 | 85 | 11 | +1736/−57, 22 files | 2026-07-16 | shortlisted |
+| #63 | 53 | 40 | 16 | +1221/−0, 3 files | 2026-07-17 | shortlisted |
+| #78 | 24 | 19 | 12 | +1036/−42, 7 files | 2026-08-07 | shortlisted |
+| #90 | 24 | 62 | 12 | +1211/−8, 7 files | 2026-08-12 | shortlisted |
+| #88 | 15 | 10 | 7 | +764/−0, 4 files | 2026-08-12 | shortlisted |
+| #103 | 13 | 5 | 6 | +932/−1, 7 files | 2026-08-13 | shortlisted |
+| #87 | 13 | 7 | 7 | +186/−106, 19 files | 2026-08-11 | rejected (toolchain-pin chore) |
+| #105 | 10 | 16 | 6 | +927/−0, 6 files | 2026-08-17 | shortlisted |
+| #89 | 9 | 18 | 7 | +973/−0, 3 files | 2026-08-12 | secondary (lab job model; add if the lab-CLI wave is extracted whole) |
+| #104 | 8 | 10 | 10 | +241/−8, 5 files | 2026-08-15 | rejected (pure docs) |
+| #79 | 4 | 1 | 5 | +133/−0, 3 files | 2026-08-03 | shortlisted (only as #78's patch pair) |
+
+## Considered and rejected
+
+- **`#87`** (pin Rust 1.97.1 / Python 3.14.7) — toolchain pin chore across 19 files;
+  no domain trajectory.
+- **`#104`** (Safe Issue → Verified Commit and PR workflows) — real review traffic but
+  docs-only; fails the [pure-docs exclusion](_index.md#avoid-for-v0-training).
+- **`#52`, `#67`, `#68`** — CI/Qodana plumbing without domain signal.
+- The Issue-#N ladder `#53`–`#60`, `#62` (orchestrator, babysit cycle, watchlist,
+  CI taxonomy, stack ordering, guardrails) is real feature work but was not measured
+  this pass — re-score it if the extract wants more than 9 PRs.


### PR DESCRIPTION
Closes #30.

Fleet inventory rewritten from a **live `gh` scan dated 2026-08-16** (the issue's own 2026-08-12 data was already stale). Review counts below are raw GitHub API totals (`reviews` / review threads — pre bot-filter); pipeline yield is measured at extraction time, as the docs now state explicitly.

## Refreshed (existing docs, no restructuring)

- **corinth-canal.md** — new "Candidate next wave" section for the GGUF/Safetensors wave: #125 (81 rev), #142 (33), #138 (11), #128 (9), #127 (7), #126 (6). Notes the #126→#138 recovery pair (potential regression→repair trajectory) and the newer GH#147 safetensors series (#152–#154, #156).
- **grok-ozempic.md** — new "Candidate next wave" for #69–#79: #74 (63 rev), #72 (54), #69 (40), #71 (25), #76 (18), #77 (16), #79 (6; merged patch-pair answering #76's bot review). Flags #83 (**112 rev / 65 threads**, repo record) and #86 (37/60) beyond the wave.
- **limen-neural.md** — "Later waves" pointer table refreshed with live numbers and extended to all issue-#28 wave B repos. Notable: kinetic-signals #39 (**109 rev**), brainstem-daemon #8 (**215 rev**), nir-rs now past #40 (#38: 61 rev). Documents the **Limen-Neural → rmems transfers** of SpikeStream.jl, kinetic-signals, and limbic-critic.

## New per-repo docs (index lines included; Index regenerated via `build_status.py`)

- **worktrees-hives.md** — `shortlist drafted` (v0.6 agentic-workflow priority). 9 shortlisted: #61 (80 rev / 90 threads), #65 (60/85), #63 (53/40), #78+#79 (review-to-patch pair), #90 (24/62), #88, #103, #105 — the post-#100 lab-CLI wave measured live.
- **theseus-quarry.md** — `shortlist drafted` (v0.6 telemetry priority). 7 of 9 merged PRs: #13 (35 rev), #8 (28, −5442-line supervisor removal), #9 (17/31), #12 (14), #18 (13), #16 (13, borderline), #11 (10/18).
- **wave-c.md** — `pointers only` org-level table for issue-#29 repos (xai-dissect #48 at 137 rev / 200 threads, thalamic-relay #20–#23 cluster, LiquidCortex.jl #45 at 100 rev, silicon-hdl, spike-viz #22→#23 pair, agoge-forger, engram-parser, hybrid-fusion).

## Policy

- **_index.md** — new "Parked (Tier C)" section outside the generated block: blackwell-kernel-lab (merged PRs now exist, but they're bench logs and issue #32 wants the agent harness removed — boundary in flux), Dependabot-dominated repos (plasticity-lab), docs-only repos.

Full wave B/C shortlists land when #28/#29 are decomposed — this PR keeps them as pointers by design.

Gate: `build_status.py --check` passes, `ruff check scripts/` clean, 135 tests pass, STATUS.md untouched, all relative links verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only inventory and shortlist updates; no pipeline, schema, or extraction code changes.
> 
> **Overview**
> **Fleet inventory** for source-repo extraction is rewritten from a **live 2026-08-16** GitHub scan (issue #30), with review/thread counts documented as **raw API totals** (pre bot-filter) and pipeline yield deferred to extraction time.
> 
> **`_index.md`** gains a **Parked (Tier C)** policy table (e.g. `blackwell-kernel-lab`, Dependabot-heavy repos, docs-only) and **three new index rows** via per-doc `<!-- index: ... -->` lines: **Theseus-Quarry**, **worktrees-hives** (`shortlist drafted`), and **wave-c** (`pointers only`).
> 
> **Already-extracted repos** get **“Candidate next wave”** or refreshed pointer tables: **corinth-canal** (GGUF/Safetensors GH#118 wave, including #126→#138 recovery), **grok-ozempic** (#69–#79 GOZ1/expert wave, #76+#79 pair), **limen-neural** (wave B repos with live counts, **Limen-Neural → rmems** transfers for SpikeStream.jl, kinetic-signals, limbic-critic).
> 
> **New docs**: **`theseus-quarry.md`** (7 telemetry PRs), **`worktrees-hives.md`** (9 agentic-workflow PRs, #78+#79 pair), **`wave-c.md`** (org-level pointers for issue #29 repos). Full wave B/C shortlists stay deferred until #28/#29 are decomposed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 931f2e0705cf0e6c56bba6ad7405d888b5bd61bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the source-repos docs from a live `gh` scan dated 2026-08-16 and introduces a “Parked (Tier C)” policy to keep stale or noisy repos out of extraction. The old inventory relied on earlier issue data; the new docs include raw GitHub review counts, note org transfers, and keep waves B/C as pointers only to avoid premature extraction.

- Refreshes existing docs with live “candidate next wave” pointers: `corinth-canal.md`, `grok-ozempic.md`, `limen-neural.md` (adds Limen‑Neural → rmems transfers and highest-density candidates).
- Adds new per-repo shortlist docs: `worktrees-hives.md` (v0.6 agentic-workflow) and `theseus-quarry.md` (v0.6 telemetry), plus org-level pointers `wave-c.md`.
- Updates `docs/source-repos/_index.md` with “Parked (Tier C)” and index lines for the new docs; links verified. Aligns with issue #30’s inventory refresh.

**Rollout**
- Do not start extraction for waves B/C; these entries are pointers only. When ready, decompose issues #28/#29 and graduate each repo to its own doc with a shortlist.
- Treat “Parked (Tier C)” repos as excluded from v0 training. Unparking requires adding a per-repo doc and index entry per `_index.md` guidance.
- When extracting `worktrees-hives` and `Theseus-Quarry`, preserve review-to-patch pairs (e.g., `#78`/`#79`) and apply generated-artifact exclusions as documented; measure pipeline yield at extraction time (raw `reviews` are pre bot-filter).

<sup>Written for commit 931f2e0705cf0e6c56bba6ad7405d888b5bd61bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/operation-prometheus/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

