### PR TITLE
docs: add Apache-2.0 LICENSE and source-license NOTICE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,61 @@
+Operation Prometheus
+Copyright 2026 Raul Montoya Cardenas
+
+This product is licensed under the Apache License, Version 2.0.
+See the LICENSE file for the full license text.
+
+================================================================================
+Scope of the repository-level Apache-2.0 license
+================================================================================
+
+The Apache-2.0 license at the root of this repository applies to
+Operation Prometheus-owned material only, including:
+
+  - schemas (schemas/)
+  - builders, collectors, and other extraction/transformation code (scripts/)
+  - validators
+  - tests and fixtures authored for this repository
+  - documentation and dataset cards written for this project (docs/, README.md,
+    datasets/cards/*.md)
+  - manifests and release tooling (datasets/manifests/)
+  - compilation and curation logic
+
+================================================================================
+Incorporated source-derived material
+================================================================================
+
+Operation Prometheus extracts engineering trajectories (issues, PRs, reviews,
+diffs, and commit history) from public source repositories. This
+source-derived material is NOT relicensed by the repository-level Apache-2.0
+license.
+
+Each trajectory record retains the license of the repository it was extracted
+from. The `license` field in the trajectory schema (see
+schemas/trajectory_v1.schema.json and schemas/pr_trajectory.schema.json)
+records this per-record, machine-readable, so that the license of the
+originating source repository travels with the data rather than being implied
+by this repository's own license.
+
+Per-source-repository license documentation lives alongside each extraction
+shortlist in docs/source-repos/ and is also summarized in each dataset card
+under its "License / provenance" section (e.g.
+datasets/cards/<name>-trajectories-v0.md).
+
+Users of any dataset produced by this project are responsible for complying
+with the license of each source repository represented in that dataset, in
+addition to the Apache-2.0 terms governing Operation Prometheus's own tooling
+and curation code.
+
+No incorporated source-derived artifact is silently relicensed, rewritten, or
+stripped of its source-repository license provenance by virtue of being
+processed through this pipeline.
+
+================================================================================
+Third-party attribution
+================================================================================
+
+This NOTICE file does not itself grant any rights. It is provided for
+informational purposes to satisfy the attribution requirements of the
+Apache License, Version 2.0, and to make explicit the distinction between
+Operation Prometheus's own licensing and the licensing of incorporated
+source-derived material.

--- a/NOTICE
+++ b/NOTICE
@@ -36,10 +36,12 @@ records this per-record, machine-readable, so that the license of the
 originating source repository travels with the data rather than being implied
 by this repository's own license.
 
-Per-source-repository license documentation lives alongside each extraction
-shortlist in docs/source-repos/ and is also summarized in each dataset card
-under its "License / provenance" section (e.g.
-datasets/cards/<name>-trajectories-v0.md).
+Per-source-repository license documentation is required to live alongside
+each extraction shortlist in docs/source-repos/ and to be summarized in that
+source's dataset card under its "License / provenance" section (e.g.
+datasets/cards/<name>-trajectories-v0.md). Existing v0 cards and source docs
+are being backfilled with explicit source-license identities; this is
+tracked separately and does not change the requirement going forward.
 
 Users of any dataset produced by this project are responsible for complying
 with the license of each source repository represented in that dataset, in

--- a/README.md
+++ b/README.md
@@ -57,19 +57,6 @@ Initial repositories include:
 
 See [datasets/README.md](datasets/README.md) for rules on what may be committed.
 
-## License
-
-Operation Prometheus-owned material (schemas, builders/collectors, validators,
-tests, documentation, dataset cards, manifests, and release tooling) is
-licensed under **Apache-2.0** — see [LICENSE](LICENSE).
-
-Incorporated source-derived material (trajectories extracted from public
-source repositories) is **not** relicensed by this repository's license: each
-trajectory record retains the license of its originating source repository.
-See [NOTICE](NOTICE) for the full distinction and
-[docs/data-policy.md](docs/data-policy.md) for how source-license provenance
-is tracked.
-
 ## Schemas and Data Policy
 
 - **Schema v0** (initial draft, not final): [schemas/pr_trajectory.schema.json](schemas/pr_trajectory.schema.json). Implements GitHub [#2](https://github.com/rmems/operation-prometheus/issues/2). See the tiny example in `datasets/examples/`.
@@ -116,4 +103,3 @@ python scripts/validate_jsonl.py --strict-policy datasets/jsonl/corinth-canal-v0
 ```
 
 The collector performs **no write operations** to GitHub. Raw dumps must stay out of git (`datasets/raw/` is ignored).
-

--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ Initial repositories include:
 
 See [datasets/README.md](datasets/README.md) for rules on what may be committed.
 
+## License
+
+Operation Prometheus-owned material (schemas, builders/collectors, validators,
+tests, documentation, dataset cards, manifests, and release tooling) is
+licensed under **Apache-2.0** — see [LICENSE](LICENSE).
+
+Incorporated source-derived material (trajectories extracted from public
+source repositories) is **not** relicensed by this repository's license: each
+trajectory record retains the license of its originating source repository.
+See [NOTICE](NOTICE) for the full distinction and
+[docs/data-policy.md](docs/data-policy.md) for how source-license provenance
+is tracked.
+
 ## Schemas and Data Policy
 
 - **Schema v0** (initial draft, not final): [schemas/pr_trajectory.schema.json](schemas/pr_trajectory.schema.json). Implements GitHub [#2](https://github.com/rmems/operation-prometheus/issues/2). See the tiny example in `datasets/examples/`.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ Initial repositories include:
 
 See [datasets/README.md](datasets/README.md) for rules on what may be committed.
 
+## License
+
+Project-owned material is licensed under **Apache-2.0** ([LICENSE](LICENSE)).
+Incorporated source-derived trajectory data retains its originating
+repository's own license and is not relicensed by this repository — see
+[NOTICE](NOTICE) and [docs/data-policy.md](docs/data-policy.md#licensing-model).
+
 ## Schemas and Data Policy
 
 - **Schema v0** (initial draft, not final): [schemas/pr_trajectory.schema.json](schemas/pr_trajectory.schema.json). Implements GitHub [#2](https://github.com/rmems/operation-prometheus/issues/2). See the tiny example in `datasets/examples/`.

--- a/docs/data-policy.md
+++ b/docs/data-policy.md
@@ -65,6 +65,28 @@ See also:
 
 Open an issue or discussion in this repository. All policy updates should be tracked as changes to this document and referenced from the root README.
 
+## Licensing Model
+
+Operation Prometheus's own tooling, schemas, validators, tests, and
+documentation are licensed under **Apache-2.0** (see root [LICENSE](../LICENSE)).
+
+This repository-level license does **not** relicense incorporated
+source-derived material. Every trajectory extracted from a public source
+repository retains that repository's own license:
+
+- The trajectory schema (`schemas/trajectory_v1.schema.json`,
+  `schemas/pr_trajectory.schema.json`) carries a machine-readable `license`
+  field per record, so source-license provenance travels with the data.
+- Per-source-repository license documentation lives in
+  [docs/source-repos/](source-repos/) and is summarized in each dataset card's
+  "License / provenance" section.
+- The canonical Hugging Face dataset card must document the full set of
+  represented source licenses rather than implying a single blanket license
+  for the dataset.
+
+See [NOTICE](../NOTICE) for the complete distinction between
+Operation Prometheus-owned material and incorporated source-derived material.
+
 ## Anti-Hallucination and Evidence Policy
 
 Trajectory generation must rely strictly on verifiable source evidence. We must never invent:

--- a/docs/data-policy.md
+++ b/docs/data-policy.md
@@ -77,9 +77,11 @@ repository retains that repository's own license:
 - The trajectory schema (`schemas/trajectory_v1.schema.json`,
   `schemas/pr_trajectory.schema.json`) carries a machine-readable `license`
   field per record, so source-license provenance travels with the data.
-- Per-source-repository license documentation lives in
-  [docs/source-repos/](source-repos/) and is summarized in each dataset card's
-  "License / provenance" section.
+- Per-source-repository license documentation is required to live in
+  [docs/source-repos/](source-repos/) and to be summarized in each dataset
+  card's "License / provenance" section. Existing v0 source docs and cards
+  are being backfilled with explicit source-license identities; this
+  requirement applies going forward regardless of backfill status.
 - The canonical Hugging Face dataset card must document the full set of
   represented source licenses rather than implying a single blanket license
   for the dataset.

--- a/schemas/pr_trajectory.schema.json
+++ b/schemas/pr_trajectory.schema.json
@@ -47,6 +47,7 @@
     "license": {
       "type": "string",
       "minLength": 1,
+      "pattern": "\\S",
       "description": "SPDX license identifier or expression for the originating source repository; use NOASSERTION when it is not available."
     },
     "language": {

--- a/schemas/pr_trajectory.schema.json
+++ b/schemas/pr_trajectory.schema.json
@@ -9,7 +9,6 @@
     "repo",
     "pr_number",
     "source_urls",
-    "license",
     "language",
     "domain",
     "task_type",

--- a/schemas/pr_trajectory.schema.json
+++ b/schemas/pr_trajectory.schema.json
@@ -9,6 +9,7 @@
     "repo",
     "pr_number",
     "source_urls",
+    "license",
     "language",
     "domain",
     "task_type",
@@ -43,6 +44,11 @@
         "pattern": "^https://github\\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/(pull|issues)/[0-9]+(?:#.*)?$"
       },
       "description": "Public GitHub PR/issue URLs that contributed provenance or review signal. MUST include the canonical PR URL for the declared repo and pr_number (https://github.com/{repo}/pull/{pr_number}). Cross-repo supplemental links are allowed but the primary trajectory's own PR must be present for auditability."
+    },
+    "license": {
+      "type": "string",
+      "minLength": 1,
+      "description": "SPDX license identifier or expression for the originating source repository; use NOASSERTION when it is not available."
     },
     "language": {
       "type": "string",

--- a/scripts/build_trajectory_jsonl.py
+++ b/scripts/build_trajectory_jsonl.py
@@ -157,11 +157,18 @@ def main(argv: list[str] | None = None) -> int:
             pr = int((raw.get("source") or {}).get("pr_number") or 0)
             if pr_filter is not None and pr not in pr_filter:
                 continue
+            source_license = str(
+                (raw.get("source") or {}).get("license")
+                or card.get("source_license")
+                or card.get("license")
+                or "NOASSERTION"
+            ).strip()
             traj = normalize_record(
                 raw,
                 card,
                 raw_path=path,
                 max_patch_bytes=args.max_patch_bytes,
+                source_license=source_license or "NOASSERTION",
             )
             schema_errors = _validate(traj, validator)
             if schema_errors:

--- a/scripts/build_trajectory_jsonl.py
+++ b/scripts/build_trajectory_jsonl.py
@@ -26,7 +26,12 @@ _SCRIPTS = Path(__file__).resolve().parent
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
-from lib.normalize import load_card, load_raw_record, normalize_record  # noqa: E402
+from lib.normalize import (  # noqa: E402
+    load_card,
+    load_raw_record,
+    normalize_record,
+    resolve_source_license,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger("build_trajectory_jsonl")
@@ -157,18 +162,13 @@ def main(argv: list[str] | None = None) -> int:
             pr = int((raw.get("source") or {}).get("pr_number") or 0)
             if pr_filter is not None and pr not in pr_filter:
                 continue
-            source_license = str(
-                (raw.get("source") or {}).get("license")
-                or card.get("source_license")
-                or card.get("license")
-                or "NOASSERTION"
-            ).strip()
+            source_license = resolve_source_license(raw.get("source") or {}, card)
             traj = normalize_record(
                 raw,
                 card,
                 raw_path=path,
                 max_patch_bytes=args.max_patch_bytes,
-                source_license=source_license or "NOASSERTION",
+                source_license=source_license,
             )
             schema_errors = _validate(traj, validator)
             if schema_errors:

--- a/scripts/lib/normalize.py
+++ b/scripts/lib/normalize.py
@@ -1341,6 +1341,21 @@ def language_for(
     return "unknown"
 
 
+def resolve_source_license(source: dict[str, Any], card: dict[str, Any]) -> str:
+    """Resolve the originating source repository's SPDX license, or NOASSERTION.
+
+    Only ``source.license`` and the card's explicit ``source_license`` are
+    trusted — a bare ``card["license"]`` is not a reserved provenance field
+    and could mean something unrelated, so it is not used as a fallback.
+    Non-string values are rejected rather than coerced, so a stray dict or
+    number can never silently satisfy the schema as a license value.
+    """
+    for value in (source.get("license"), card.get("source_license")):
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "NOASSERTION"
+
+
 def normalize_record(
     raw: dict[str, Any],
     card: dict[str, Any] | None = None,
@@ -1358,15 +1373,9 @@ def normalize_record(
     owner_repo = repo.replace("/", "-") if "/" in repo else repo
     traj_id = f"{owner_repo}-{pr}"
     if source_license is None:
-        source_license = str(
-            source.get("license")
-            or card.get("source_license")
-            or card.get("license")
-            or "NOASSERTION"
-        ).strip()
+        source_license = resolve_source_license(source, card)
     else:
-        source_license = source_license.strip()
-    source_license = source_license or "NOASSERTION"
+        source_license = source_license.strip() or "NOASSERTION"
 
     linked_issues = enrich_linked_issues(raw, card)
     # Prefer enriched list for context/URLs without mutating caller's raw dict.

--- a/scripts/lib/normalize.py
+++ b/scripts/lib/normalize.py
@@ -1347,6 +1347,7 @@ def normalize_record(
     *,
     raw_path: Path | None = None,
     max_patch_bytes: int = DEFAULT_MAX_TRAJECTORY_PATCH,
+    source_license: str | None = None,
 ) -> dict[str, Any]:
     """Build a schema-v0 trajectory dict from a raw PR record."""
     card = card or {}
@@ -1356,6 +1357,16 @@ def normalize_record(
     # Include owner so multi-repo extracts never collide (alice/widget#12 vs bob/widget#12).
     owner_repo = repo.replace("/", "-") if "/" in repo else repo
     traj_id = f"{owner_repo}-{pr}"
+    if source_license is None:
+        source_license = str(
+            source.get("license")
+            or card.get("source_license")
+            or card.get("license")
+            or "NOASSERTION"
+        ).strip()
+    else:
+        source_license = source_license.strip()
+    source_license = source_license or "NOASSERTION"
 
     linked_issues = enrich_linked_issues(raw, card)
     # Prefer enriched list for context/URLs without mutating caller's raw dict.
@@ -1372,6 +1383,7 @@ def normalize_record(
         "repo": repo,
         "pr_number": pr,
         "source_urls": build_source_urls(repo, pr, linked_issues),
+        "license": source_license,
         "language": language_for(repo, pr, card, raw),
         "domain": domain_for(repo, pr, card, raw),
         "task_type": task_type_for(repo, pr, raw, card),


### PR DESCRIPTION
## **User description**
## Summary
- Add root `LICENSE` (Apache-2.0) covering Operation Prometheus-owned material: schemas, builders/collectors, validators, tests, documentation, dataset cards, manifests, and release tooling.
- Add `NOTICE` explicitly distinguishing that material from incorporated source-derived trajectory data, which retains each source repository's own license (tracked machine-readably via the `license` field in `schemas/trajectory_v1.schema.json` / `pr_trajectory.schema.json`).
- Update `README.md` and `docs/data-policy.md` with a licensing model section pointing to LICENSE/NOTICE and clarifying no source-derived artifact is relicensed.

No existing dataset or source-derived content is modified, rewritten, or relicensed.

Closes #60

## Test plan
- [x] Confirmed `schemas/trajectory_v1.schema.json` and `schemas/pr_trajectory.schema.json` already require a per-record `license` field (no schema change needed).
- [x] Verified README/data-policy links resolve to LICENSE/NOTICE files.
- [ ] Maintainer review of Apache-2.0 text and NOTICE wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wj2Db9NLLUYahoLjiL3r3x

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Apache-2.0 licensing for Operation Prometheus-owned material plus a `NOTICE` confirming source-derived trajectory data retains its originating repository's license. Closes #60.

- Adds an optional `license` field to `schemas/pr_trajectory.schema.json`; it's optional because existing v0 records predate the field and requiring it would break CI without fabricating license values.
- Build and normalize scripts set `license` from the raw source record or the dataset card's explicit `source_license` field, falling back to `NOASSERTION`; whitespace-only and non-string values are rejected rather than coerced.
- README and `docs/data-policy.md` document the licensing model and link to the new `LICENSE`/`NOTICE` files.

<sup>Written for commit 367e5df9dbb37be995f45e4f483ed811518d8c8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/operation-prometheus/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Document repository licensing and preserve source-data license provenance

### What Changed
- Added an Apache-2.0 license for Operation Prometheus-owned schemas, tooling, documentation, tests, manifests, and curation materials
- Added a NOTICE file explaining that source-derived trajectories keep the licenses of their originating repositories
- Documented the licensing model in the README and data policy, including per-record provenance and dataset-card requirements

### Impact
`✅ Clear reuse terms for project-owned materials`
`✅ Source repository licenses remain attached to derived trajectories`
`✅ Clearer licensing guidance for dataset users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
