### PR TITLE
fix: repair Cloud Agent Dockerfile build

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -8,12 +8,13 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         git=1:2.39.5-0+deb12u3 \
         curl=7.88.1-10+deb12u15 \
-        ca-certificates=20230311+deb12u1 \
+        ca-certificates=20250419~deb12u1 \
         jq=1.6-2.1+deb12u2 \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for container security.
 RUN groupadd -r prometheus && useradd -r -g prometheus -m -d /home/prometheus prometheus \
+    && mkdir -p /workspace \
     && chown -R prometheus:prometheus /workspace /usr/local
 
 WORKDIR /workspace


### PR DESCRIPTION
## **User description**
## Problem

The Cloud Agent / dev container image (`.cursor/Dockerfile`) failed to build:

1. **apt downgrade error** — the pinned `ca-certificates=20230311+deb12u1` is older than what the current `python:3.12-bookworm` base ships (`20250419~deb12u1`), so apt aborted with `Packages were downgraded and -y was used without --allow-downgrades`.
2. **missing /workspace** — the base image no longer contains `/workspace`, so `chown -R prometheus:prometheus /workspace ...` failed with `cannot access '/workspace'`.

## Fix

- Bump the `ca-certificates` pin to `20250419~deb12u1` (current candidate in bookworm).
- `mkdir -p /workspace` before the `chown`.

## Verification

- `docker build -f .cursor/Dockerfile` completes successfully.
- Smoke test in the image: runs as `prometheus` user, `jq-1.6`, `git 2.39.5`.
- `ruff check scripts/` and `pytest -q` (207 passed) — no code changes, sanity only.

Intentionally minimal so it can merge early; any further image hardening (e.g. HEALTHCHECK, Hadolint nits) can go in a follow-up cleanup PR.

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
Restore successful Cloud Agent container builds

### What Changed
- Updates the container's certificate package to match the current Python base image, preventing package installation failures.
- Creates the `/workspace` directory before assigning ownership so the image setup completes successfully.
- Cloud Agent containers now build with the expected workspace and non-root user configuration.

### Impact
`✅ Successful Cloud Agent image builds`
`✅ Reliable workspace setup`
`✅ Fewer container setup failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Cloud Agent Dockerfile build so the dev container image builds successfully again.

- Updates the `ca-certificates` pin to `20250419~deb12u1`, matching the current base image and avoiding an apt downgrade error.
- Creates `/workspace` before chowning it, since the base image no longer includes that directory.

<sup>Written for commit 48dbcd503cf15a3bde7526259d31ecb8e796b2d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/operation-prometheus/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

